### PR TITLE
implement dbshell

### DIFF
--- a/django_mongodb/client.py
+++ b/django_mongodb/client.py
@@ -4,11 +4,40 @@ from django.db.backends.base.client import BaseDatabaseClient
 
 
 class DatabaseClient(BaseDatabaseClient):
-    executable_name = "mongo"
+    executable_name = "mongosh"
 
     @classmethod
-    def settings_to_cmd_args_env(cls, settings_dict, parameters):
-        raise NotImplementedError
+    def settings_to_cmd_args_env(cls, settings_dict, parameters):  # noqa: ARG003 parameters unused
+        options = settings_dict.get("OPTIONS", {})
+        args = [cls.executable_name]
+
+        host = settings_dict["HOST"]
+        port = settings_dict["PORT"]
+        dbname = settings_dict["NAME"]
+        user = settings_dict["USER"]
+        passwd = settings_dict["PASSWORD"]
+        auth_database = options.get("authSource")
+        auth_mechanism = options.get("authMechanism")
+        retry_writes = options.get("retryWrites")
+
+        if host:
+            args += ["--host", host]
+        if port:
+            args += ["--port", port]
+        if user:
+            args += ["--username", user]
+        if passwd:
+            args += ["--password", passwd]
+        if auth_database:
+            args += ["--authenticationDatabase", auth_database]
+        if auth_mechanism:
+            args += ["--authenticationMechanism", auth_mechanism]
+        if retry_writes is not None:
+            args += ["--retryWrites", str(retry_writes).lower()]
+
+        args.append(dbname)
+
+        return args, None
 
     def runshell(self, parameters):
         sigint_handler = signal.getsignal(signal.SIGINT)


### PR DESCRIPTION
#### Implementation of MongoDB connection setup method in DatabaseClient class.

**Description**:
This PR introduces the `settings_to_cmd_args_env` method in the `DatabaseClient` class.

**Limitations**:
1. how do we handle options like `awsIamSessionToken`.
2. Currently, password hiding under environment variables is not supported.

Feedback and contributions are welcomed to address these limitations and refine the implementation.

- [x] Where do I have to put the unit test, I already wrote it, but I don't know where those have to be.. will they be merged into Django test?  solved. [PR open](https://github.com/mongodb-forks/django/pull/1)
- [ ] Hide password if an exception is raised.