### PR TITLE
fix QuerySet results when Q() conditions are empty or full

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -77,6 +77,7 @@ jobs:
           lookup.tests.LookupQueryingTests.test_isnull_lookup_in_filter
           model_fields
           or_lookups
+          queries.tests.Ticket12807Tests.test_ticket_12807
           sessions_tests
           update
 

--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.core.exceptions import EmptyResultSet
+from django.core.exceptions import EmptyResultSet, FullResultSet
 from django.db import (
     DatabaseError,
     IntegrityError,
@@ -128,7 +128,10 @@ class SQLCompiler(compiler.SQLCompiler):
         self.check_query()
         self.setup_query()
         query = self.query_class(self, columns)
-        query.add_filters(self.query.where)
+        try:
+            query.add_filters(self.query.where)
+        except FullResultSet:
+            query.mongo_query = []
         query.order_by(self._get_ordering())
 
         # This at least satisfies the most basic unit tests.

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -34,8 +34,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # 'TruncDate' object has no attribute 'alias'
         "model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_with_use_tz",
         "model_fields.test_datetimefield.DateTimeFieldTests.test_lookup_date_without_use_tz",
-        # Empty queryset ORed (|) with another gives empty results.
-        "or_lookups.tests.OrLookupsTests.test_empty_in",
     }
 
     django_test_skips = {


### PR DESCRIPTION
fixes #22

This draft seems to work for simple cases, but not for more complicated cases like [`queries.tests.Ticket12807Tests.test_ticket_12807`](https://github.com/django/django/blob/a09082a9bec18f8e3ee8c10d473013ec67ffe93b/tests/queries/tests.py#L4195). I'm not sure it can work without some refactoring of `add_filters()`.