### PR TITLE
store DateField and TimeField as datetime (rather than string)

### DIFF
--- a/django_mongodb/operations.py
+++ b/django_mongodb/operations.py
@@ -10,6 +10,12 @@ from django.utils import timezone
 class DatabaseOperations(BaseDatabaseOperations):
     compiler_module = "django_mongodb.compiler"
 
+    def adapt_datefield_value(self, value):
+        """Store DateField as datetime."""
+        if value is None:
+            return None
+        return datetime.datetime.combine(value, datetime.datetime.min.time())
+
     def adapt_datetimefield_value(self, value):
         if not settings.USE_TZ and value is not None and timezone.is_naive(value):
             value = timezone.make_aware(value)
@@ -33,7 +39,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def convert_datefield_value(self, value, expression, connection):
         if value is not None:
-            value = datetime.date.fromisoformat(value)
+            value = value.date()
         return value
 
     def convert_datetimefield_value(self, value, expression, connection):

--- a/django_mongodb/operations.py
+++ b/django_mongodb/operations.py
@@ -21,6 +21,12 @@ class DatabaseOperations(BaseDatabaseOperations):
             value = timezone.make_aware(value)
         return value
 
+    def adapt_timefield_value(self, value):
+        """Store TimeField as datetime."""
+        if value is None:
+            return None
+        return datetime.datetime.combine(datetime.datetime.min.date(), value)
+
     def get_db_converters(self, expression):
         converters = super().get_db_converters(expression)
         internal_type = expression.output_field.get_internal_type()
@@ -55,7 +61,7 @@ class DatabaseOperations(BaseDatabaseOperations):
 
     def convert_timefield_value(self, value, expression, connection):
         if value is not None:
-            value = datetime.time.fromisoformat(value)
+            value = value.time()
         return value
 
     def convert_uuidfield_value(self, value, expression, connection):


### PR DESCRIPTION
This makes querying on them easier (e.g. extract, truncate).