### PR TITLE
make all lookups use $expr

### DIFF
--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -138,7 +138,7 @@ class SQLCompiler(compiler.SQLCompiler):
         self.setup_query()
         query = self.query_class(self, columns)
         try:
-            query.mongo_query = self.query.where.as_mql(self, self.connection)
+            query.mongo_query = {"$expr": self.query.where.as_mql(self, self.connection)}
         except FullResultSet:
             query.mongo_query = {}
         query.order_by(self._get_ordering())

--- a/django_mongodb/expressions.py
+++ b/django_mongodb/expressions.py
@@ -6,14 +6,9 @@ def col(self, compiler, connection):  # noqa: ARG001
 
 
 def value(self, compiler, connection):  # noqa: ARG001
-    return self.value
-
-
-def value_agg(self, compiler, connection):  # noqa: ARG001
     return {"$literal": self.value}
 
 
 def register_expressions():
     Col.as_mql = col
     Value.as_mql = value
-    Value.as_mql_agg = value_agg

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -21,8 +21,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # Database defaults not supported: bson.errors.InvalidDocument:
         # cannot encode object: <django.db.models.expressions.DatabaseDefault
         "basic.tests.ModelInstanceCreationTests.test_save_primary_with_db_default",
-        # Query for chained lookups not generated correctly.
-        "lookup.tests.LookupTests.test_chain_date_time_lookups",
         # 'NulledTransform' object has no attribute 'as_mql'.
         "lookup.tests.LookupTests.test_exact_none_transform",
         # "Save with update_fields did not affect any rows."
@@ -56,11 +54,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # the result back to UTC.
         "db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_trunc_func_with_timezone",
         "db_functions.datetime.test_extract_trunc.DateFunctionWithTimeZoneTests.test_trunc_timezone_applied_before_truncation",
-        # $and must be an array
-        "db_functions.tests.FunctionTests.test_function_as_filter",
         # pk__in=queryset doesn't work because subqueries aren't a thing in
         # MongoDB.
         "annotations.tests.NonAggregateAnnotationTestCase.test_annotation_and_alias_filter_in_subquery",
+        # Length of null considered zero rather than null.
+        "db_functions.text.test_length.LengthTests.test_basic",
     }
 
     django_test_skips = {
@@ -164,10 +162,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupTests.test_exact_exists",
             "lookup.tests.LookupTests.test_nested_outerref_lhs",
             "lookup.tests.LookupQueryingTests.test_filter_exists_lhs",
-            # QuerySet.alias(greater=GreaterThan(F("year"), 1910)).filter(greater=True)
-            # generates incorrect an incorrect query:
-            # {'$expr': {'$eq': [{'year': {'$gt': 1910}}, True]}}}
-            "lookup.tests.LookupQueryingTests.test_alias",
             # annotate() with combined expressions doesn't work:
             # 'WhereNode' object has no attribute 'field'
             "lookup.tests.LookupQueryingTests.test_combined_annotated_lookups_in_filter",
@@ -175,8 +169,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupQueryingTests.test_combined_lookups",
             # Case not supported.
             "lookup.tests.LookupQueryingTests.test_conditional_expression",
-            # Using expression in filter() doesn't work.
-            "lookup.tests.LookupQueryingTests.test_filter_lookup_lhs",
             # Subquery not supported.
             "annotations.tests.NonAggregateAnnotationTestCase.test_empty_queryset_annotation",
             "db_functions.comparison.test_coalesce.CoalesceTests.test_empty_queryset",
@@ -202,8 +194,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             # Func not implemented.
             "annotations.tests.NonAggregateAnnotationTestCase.test_custom_functions",
             "annotations.tests.NonAggregateAnnotationTestCase.test_custom_functions_can_ref_other_functions",
-            # Floor not implemented.
-            "annotations.tests.NonAggregateAnnotationTestCase.test_custom_transform_annotation",
             # BaseDatabaseOperations may require a format_for_duration_arithmetic().
             "annotations.tests.NonAggregateAnnotationTestCase.test_mixed_type_annotation_date_interval",
             # FieldDoesNotExist with ordering.
@@ -212,9 +202,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "annotations.tests.NonAggregateAnnotationTestCase.test_order_by_annotation",
             # annotate().filter().count() gives incorrect results.
             "db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_year_exact_lookup",
-            # Year lookup + lt/gt crashes: 'dict' object has no attribute 'startswith'
-            "db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_year_greaterthan_lookup",
-            "db_functions.datetime.test_extract_trunc.DateFunctionTests.test_extract_year_lessthan_lookup",
         },
         "Count doesn't work in QuerySet.annotate()": {
             "annotations.tests.AliasTests.test_alias_annotate_with_aggregation",
@@ -307,28 +294,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "timezones.tests.NewDatabaseTests.test_cursor_explicit_time_zone",
             "timezones.tests.NewDatabaseTests.test_raw_sql",
         },
-        "Transform not supported.": {
-            "db_functions.math.test_abs.AbsTests.test_transform",
-            "db_functions.math.test_acos.ACosTests.test_transform",
-            "db_functions.math.test_asin.ASinTests.test_transform",
-            "db_functions.math.test_atan.ATanTests.test_transform",
-            "db_functions.math.test_ceil.CeilTests.test_transform",
-            "db_functions.math.test_cos.CosTests.test_transform",
-            "db_functions.math.test_cot.CotTests.test_transform",
-            "db_functions.math.test_degrees.DegreesTests.test_transform",
-            "db_functions.math.test_exp.ExpTests.test_transform",
-            "db_functions.math.test_floor.FloorTests.test_transform",
-            "db_functions.math.test_ln.LnTests.test_transform",
-            "db_functions.math.test_radians.RadiansTests.test_transform",
-            "db_functions.math.test_round.RoundTests.test_transform",
-            "db_functions.math.test_sin.SinTests.test_transform",
-            "db_functions.math.test_sqrt.SqrtTests.test_transform",
-            "db_functions.math.test_tan.TanTests.test_transform",
+        "Bilateral transform not implemented.": {
             "db_functions.tests.FunctionTests.test_func_transform_bilateral",
             "db_functions.tests.FunctionTests.test_func_transform_bilateral_multivalue",
-            "db_functions.text.test_strindex.StrIndexTests.test_filtering",
-            "db_functions.text.test_length.LengthTests.test_basic",
-            "db_functions.text.test_length.LengthTests.test_transform",
         },
         "MongoDB does not support this database function.": {
             "db_functions.datetime.test_now.NowTests",

--- a/django_mongodb/lookups.py
+++ b/django_mongodb/lookups.py
@@ -1,27 +1,14 @@
 from django.db import NotSupportedError
 from django.db.models.fields.related_lookups import In, MultiColSource, RelatedIn
-from django.db.models.lookups import BuiltinLookup, Exact, IsNull, UUIDTextMixin
+from django.db.models.lookups import BuiltinLookup, IsNull, UUIDTextMixin
 
 from .query_utils import process_lhs, process_rhs
 
 
 def builtin_lookup(self, compiler, connection):
-    lhs_mql = process_lhs(self, compiler, connection, bare_column_ref=True)
-    value = process_rhs(self, compiler, connection)
-    rhs_mql = connection.mongo_operators[self.lookup_name](value)
-    return {lhs_mql: rhs_mql}
-
-
-def builtin_lookup_agg(self, compiler, connection):
     lhs_mql = process_lhs(self, compiler, connection)
     value = process_rhs(self, compiler, connection)
-    return connection.mongo_aggregations[self.lookup_name](lhs_mql, value)
-
-
-def exact(self, compiler, connection):
-    lhs_mql = process_lhs(self, compiler, connection)
-    value = process_rhs(self, compiler, connection)
-    return {"$expr": {"$eq": [lhs_mql, value]}}
+    return connection.mongo_operators[self.lookup_name](lhs_mql, value)
 
 
 def in_(self, compiler, connection):
@@ -33,9 +20,8 @@ def in_(self, compiler, connection):
 def is_null(self, compiler, connection):
     if not isinstance(self.rhs, bool):
         raise ValueError("The QuerySet value for an isnull lookup must be True or False.")
-    lhs_mql = process_lhs(self, compiler, connection, bare_column_ref=True)
-    rhs_mql = connection.mongo_operators["isnull"](self.rhs)
-    return {lhs_mql: rhs_mql}
+    lhs_mql = process_lhs(self, compiler, connection)
+    return connection.mongo_operators["isnull"](lhs_mql, self.rhs)
 
 
 def uuid_text_mixin(self, compiler, connection):  # noqa: ARG001
@@ -44,8 +30,6 @@ def uuid_text_mixin(self, compiler, connection):  # noqa: ARG001
 
 def register_lookups():
     BuiltinLookup.as_mql = builtin_lookup
-    BuiltinLookup.as_mql_agg = builtin_lookup_agg
-    Exact.as_mql = exact
     In.as_mql = RelatedIn.as_mql = in_
     IsNull.as_mql = is_null
     UUIDTextMixin.as_mql = uuid_text_mixin

--- a/django_mongodb/query.py
+++ b/django_mongodb/query.py
@@ -91,8 +91,7 @@ class MongoQuery:
                 column = expr.target.column
             except AttributeError:
                 # Generate the MQL for an annotation.
-                method = "as_mql_agg" if hasattr(expr, "as_mql_agg") else "as_mql"
-                fields[name] = getattr(expr, method)(self.compiler, self.connection)
+                fields[name] = expr.as_mql(self.compiler, self.connection)
             else:
                 # If name != column, then this is an annotatation referencing
                 # another column.
@@ -155,8 +154,7 @@ def where_node(self, compiler, connection):
         raise FullResultSet
 
     if self.negated and mql:
-        lhs, rhs = next(iter(mql.items()))
-        mql = {lhs: {"$not": rhs}}
+        mql = {"$eq": [mql, {"$literal": False}]}
 
     return mql
 


### PR DESCRIPTION
Change the current lookup for $expr. With this, we can handle queries where the rhs is more than a simple value, such as another column.