### PR TITLE
fix QuerySet.annotate() crash with combined expression

### DIFF
--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -83,7 +83,7 @@ class SQLCompiler(compiler.SQLCompiler):
                 if column_alias is not None and column_alias != self.collection_name
                 else entity
             )
-            result.append(obj.get(name, col.field.get_default()))
+            result.append(obj.get(name))
         return result
 
     def check_query(self):

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -275,11 +275,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "timezones.tests.NewDatabaseTests.test_query_annotation",
         },
         "QuerySet.annotate() has some limitations.": {
-            # annotate() with combined expressions doesn't work:
-            # 'WhereNode' object has no attribute 'field'
-            "lookup.tests.LookupQueryingTests.test_combined_annotated_lookups_in_filter",
-            "lookup.tests.LookupQueryingTests.test_combined_annotated_lookups_in_filter_false",
-            "lookup.tests.LookupQueryingTests.test_combined_lookups",
             # Invalid $project :: caused by :: Unknown expression $count,
             "annotations.tests.NonAggregateAnnotationTestCase.test_combined_expression_annotation_with_aggregation",
             "annotations.tests.NonAggregateAnnotationTestCase.test_combined_f_expression_annotation_with_aggregation",


### PR DESCRIPTION
This fallback came from the inital commit of [djangotoolbox](https://github.com/django-nonrel/djangotoolbox/commit/2fc68bfb46e528a3890136b5e429262f6c9308f0), however, I don't think it's a good idea to populate model data that's not in the database.