### PR TITLE
add xor support for Q objects

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -99,6 +99,7 @@ jobs:
           sessions_tests
           timezones
           update
+          xor_lookups
 
   docs:
     name: Docs Checks


### PR DESCRIPTION
The implementation is adapted from Django's [`WhereNode.as_sql()`](https://github.com/django/django/blob/dfd63ff43408e7901cc214b0482a7f844244d439/django/db/models/sql/where.py#L131-L147).

fixes #27 