### PR TITLE
remove test_filter_reverse_non_integer_pk from expected failures

### DIFF
--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -101,7 +101,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "queries.tests.Queries1Tests.test_ticket_10790_4",
         "queries.tests.Queries1Tests.test_ticket_10790_6",
         "queries.tests.Queries1Tests.test_ticket_10790_7",
-        "queries.tests.Queries4Tests.test_filter_reverse_non_integer_pk",
         "queries.tests.Queries4Tests.test_ticket15316_exclude_false",
         "queries.tests.Queries4Tests.test_ticket15316_filter_true",
         "queries.tests.Queries4Tests.test_ticket15316_one2one_exclude_false",


### PR DESCRIPTION
This test required microsecond support and has been fixed on the Django fork:
```diff
diff --git a/tests/queries/models.py b/tests/queries/models.py
index 9f4cf040b6..546f9fad5b 100644
--- a/tests/queries/models.py
+++ b/tests/queries/models.py
@@ -4,7 +4,7 @@ Various complex queries that have been problematic in the past.
 
 import datetime
 
-from django.db import models
+from django.db import connection, models
 from django.db.models.functions import Now
 
 
@@ -66,8 +66,17 @@ class Annotation(models.Model):
         return self.name
 
 
+def now():
+    value = datetime.datetime.now()
+    return (
+        value
+        if connection.features.supports_microsecond_precision
+        else value.replace(microsecond=0)
+    )
+
+
 class DateTimePK(models.Model):
-    date = models.DateTimeField(primary_key=True, default=datetime.datetime.now)
+    date = models.DateTimeField(primary_key=True, default=now)
 
     class Meta:
         ordering = ["date"]

```