### PR TITLE
fix crash of DecimalField lookup with F expression

### DIFF
--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -70,9 +70,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "model_fields.test_jsonfield.TestQuerying.test_order_grouping_custom_decoder",
         "model_fields.test_jsonfield.TestQuerying.test_ordering_by_transform",
         "model_fields.test_jsonfield.TestQuerying.test_ordering_grouping_by_key_transform",
-        # DecimalField lookup with F expression crashes:
-        # decimal.InvalidOperation: [<class 'decimal.ConversionSyntax'>]
-        "lookup.tests.LookupTests.test_lookup_rhs",
         # Wrong results in queries with multiple tables.
         "annotations.tests.NonAggregateAnnotationTestCase.test_annotation_reverse_m2m",
         "annotations.tests.NonAggregateAnnotationTestCase.test_annotation_with_m2m",

--- a/django_mongodb/query_utils.py
+++ b/django_mongodb/query_utils.py
@@ -34,6 +34,9 @@ def process_rhs(node, compiler, connection):
             value = value[0]
     if hasattr(node, "prep_lookup_value_mongo"):
         value = node.prep_lookup_value_mongo(value)
+    # No need to prepare expressions like F() objects.
+    if hasattr(rhs, "resolve_expression"):
+        return value
     return connection.ops.prep_lookup_value(value, node.lhs.output_field, node.lookup_name)
 
 


### PR DESCRIPTION
Extracted from https://github.com/mongodb-labs/django-mongodb/pull/84.