### PR TITLE
made empty query handling use NothingNode

### DIFF
--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -119,8 +119,6 @@ class SQLCompiler(compiler.SQLCompiler):
 
     def check_query(self):
         """Check if the current query is supported by the database."""
-        if self.query.is_empty():
-            raise EmptyResultSet()
         if self.query.distinct or getattr(
             # In the case of Query.distinct().count(), the distinct attribute
             # will be set on the inner_query.

--- a/django_mongodb/query.py
+++ b/django_mongodb/query.py
@@ -97,8 +97,6 @@ class MongoQuery:
 
         Use `limit` or `skip` to override those options of the query.
         """
-        if self.query.low_mark == self.query.high_mark:
-            return []
         fields = {}
         for name, expr in self.columns or []:
             try:

--- a/django_mongodb/query.py
+++ b/django_mongodb/query.py
@@ -8,7 +8,7 @@ from django.db.models.functions import Mod
 from django.db.models.lookups import Exact
 from django.db.models.sql.constants import INNER
 from django.db.models.sql.datastructures import Join
-from django.db.models.sql.where import AND, OR, XOR, WhereNode
+from django.db.models.sql.where import AND, OR, XOR, NothingNode, WhereNode
 from pymongo import ASCENDING, DESCENDING
 from pymongo.errors import DuplicateKeyError, PyMongoError
 
@@ -282,4 +282,5 @@ def where_node(self, compiler, connection):
 
 def register_nodes():
     Join.as_mql = join
+    NothingNode.as_mql = NothingNode.as_sql
     WhereNode.as_mql = where_node


### PR DESCRIPTION
This is consistent with Django's SQLCompiler. Also, whether or not a query is supported, shouldn't depend on whether or not it's empty.