### PR TITLE
fix MongoAutoField ModelForm bugs

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -97,6 +97,7 @@ jobs:
           m2m_through_regress
           m2o_recursive
           model_fields
+          model_forms
           one_to_one
           ordering
           or_lookups

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -69,16 +69,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "aggregation_regress.tests.AggregationTests.test_more_more_more3",
         # Incorrect JOIN with GenericRelation gives incorrect results.
         "aggregation_regress.tests.AggregationTests.test_aggregation_with_generic_reverse_relation",
-        # MongoAutoField.get_prep_value() must accept strings.
-        "model_forms.test_modelchoicefield.ModelChoiceFieldTests.test_choices",
-        "model_forms.test_modelchoicefield.ModelChoiceFieldTests.test_clean_model_instance",
+        # MongoAutoField.get_prep_value() must accept numeric pks.
         "model_forms.tests.ModelFormBasicTests.test_int_pks",
-        "model_forms.tests.ModelFormBasicTests.test_m2m_editing",
-        "model_forms.tests.ModelMultipleChoiceFieldTests.test_clean_does_deduplicate_values",
-        "model_forms.tests.ModelMultipleChoiceFieldTests.test_model_multiple_choice_field",
-        "model_forms.tests.ModelOneToOneFieldTests.test_onetoonefield",
-        "model_forms.tests.ModelFormBasicTests.test_initial_values",
-        "model_forms.tests.ModelMultipleChoiceFieldTests.test_model_multiple_choice_show_hidden_initial",
         # AutoField (IntegerField) validators crash MongoAutoField.
         "model_forms.tests.ModelFormBasicTests.test_recleaning_model_form_instance",
     }

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -69,8 +69,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "aggregation_regress.tests.AggregationTests.test_more_more_more3",
         # Incorrect JOIN with GenericRelation gives incorrect results.
         "aggregation_regress.tests.AggregationTests.test_aggregation_with_generic_reverse_relation",
-        # MongoAutoField.get_prep_value() must accept numeric pks.
-        "model_forms.tests.ModelFormBasicTests.test_int_pks",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -69,6 +69,18 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "aggregation_regress.tests.AggregationTests.test_more_more_more3",
         # Incorrect JOIN with GenericRelation gives incorrect results.
         "aggregation_regress.tests.AggregationTests.test_aggregation_with_generic_reverse_relation",
+        # MongoAutoField.get_prep_value() must accept strings.
+        "model_forms.test_modelchoicefield.ModelChoiceFieldTests.test_choices",
+        "model_forms.test_modelchoicefield.ModelChoiceFieldTests.test_clean_model_instance",
+        "model_forms.tests.ModelFormBasicTests.test_int_pks",
+        "model_forms.tests.ModelFormBasicTests.test_m2m_editing",
+        "model_forms.tests.ModelMultipleChoiceFieldTests.test_clean_does_deduplicate_values",
+        "model_forms.tests.ModelMultipleChoiceFieldTests.test_model_multiple_choice_field",
+        "model_forms.tests.ModelOneToOneFieldTests.test_onetoonefield",
+        "model_forms.tests.ModelFormBasicTests.test_initial_values",
+        "model_forms.tests.ModelMultipleChoiceFieldTests.test_model_multiple_choice_show_hidden_initial",
+        # AutoField (IntegerField) validators crash MongoAutoField.
+        "model_forms.tests.ModelFormBasicTests.test_recleaning_model_form_instance",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {
@@ -113,6 +125,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "QuerySet.prefetch_related() is not supported on MongoDB.": {
             "m2m_through_regress.test_multitable.MultiTableTests.test_m2m_prefetch_proxied",
             "m2m_through_regress.test_multitable.MultiTableTests.test_m2m_prefetch_reverse_proxied",
+            "model_forms.tests.OtherModelFormTests.test_prefetch_related_queryset",
         },
         "QuerySet.update() with expression not supported.": {
             "annotations.tests.AliasTests.test_update_with_alias",
@@ -235,6 +248,11 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "lookup.tests.LookupTests.test_exact_exists",
             "lookup.tests.LookupTests.test_nested_outerref_lhs",
             "lookup.tests.LookupQueryingTests.test_filter_exists_lhs",
+            "model_forms.tests.LimitChoicesToTests.test_fields_for_model_applies_limit_choices_to",
+            "model_forms.tests.LimitChoicesToTests.test_limit_choices_to_callable_for_fk_rel",
+            "model_forms.tests.LimitChoicesToTests.test_limit_choices_to_callable_for_m2m_rel",
+            "model_forms.tests.LimitChoicesToTests.test_limit_choices_to_m2m_through",
+            "model_forms.tests.LimitChoicesToTests.test_limit_choices_to_no_duplicates",
             "queries.tests.ExcludeTest17600.test_exclude_plain",
             "queries.tests.ExcludeTest17600.test_exclude_with_q_is_equal_to_plain_exclude_variation",
             "queries.tests.ExcludeTest17600.test_exclude_with_q_object_no_distinct",

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -71,8 +71,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "aggregation_regress.tests.AggregationTests.test_aggregation_with_generic_reverse_relation",
         # MongoAutoField.get_prep_value() must accept numeric pks.
         "model_forms.tests.ModelFormBasicTests.test_int_pks",
-        # AutoField (IntegerField) validators crash MongoAutoField.
-        "model_forms.tests.ModelFormBasicTests.test_recleaning_model_form_instance",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {

--- a/django_mongodb/fields/auto.py
+++ b/django_mongodb/fields/auto.py
@@ -26,13 +26,16 @@ class MongoAutoField(AutoField):
         try:
             return ObjectId(value)
         except errors.InvalidId as e:
+            # A manually assigned integer ID?
+            if isinstance(value, str) and value.isdigit():
+                return int(value)
             raise ValueError(f"Field '{self.name}' expected an ObjectId but got {value!r}.") from e
 
     def rel_db_type(self, connection):
         return Field().db_type(connection=connection)
 
     def to_python(self, value):
-        if value is None:
+        if value is None or isinstance(value, int):
             return value
         try:
             return ObjectId(value)

--- a/django_mongodb/fields/auto.py
+++ b/django_mongodb/fields/auto.py
@@ -1,6 +1,7 @@
 from bson import ObjectId, errors
 from django.core import exceptions
 from django.db.models.fields import AutoField, Field
+from django.utils.functional import cached_property
 from django.utils.translation import gettext_lazy as _
 
 
@@ -41,3 +42,8 @@ class MongoAutoField(AutoField):
                 code="invalid",
                 params={"value": value},
             ) from None
+
+    @cached_property
+    def validators(self):
+        # Avoid IntegerField validators inherited from AutoField.
+        return [*self.default_validators, *self._validators]


### PR DESCRIPTION
The mongodb-5.0.x branch of the Django fork will be updated with the contents of the temporary branch right before merging this. Namely, there are a two spots (example diff below) where I previously removed `str(obj.pk)` because it didn't work with `MongoAutoField`. It turns out, this needs to work because `ModelForm` [makes use of it](https://github.com/django/django/blob/main/django/forms/models.py#L1650-L1658).
```diff
diff --git a/tests/many_to_many/tests.py b/tests/many_to_many/tests.py
index 7915f29bdd..7ed3b80abc 100644
--- a/tests/many_to_many/tests.py
+++ b/tests/many_to_many/tests.py
@@ -156,7 +156,7 @@ class ManyToManyTests(TestCase):
         # A single SELECT query is necessary to compare existing values to the
         # provided one; no INSERT should be attempted.
         with self.assertNumQueries(1):
-            self.a1.publications.add(self.p1.pk)
+            self.a1.publications.add(str(self.p1.pk))
         self.assertEqual(self.a1.publications.get(), self.p1)
 
     @skipUnlessDBFeature("supports_ignore_conflicts")
```