### PR TITLE
add support for QuerySet.explain()

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,16 @@ And whenever you run `python manage.py startapp`, you must remove the line:
 
 from the new application's `apps.py` file.
 
+## Notes on Django QuerySets
+
+* `QuerySet.explain()` supports the [`comment` and `verbosity` options](
+  https://www.mongodb.com/docs/manual/reference/command/explain/#command-fields).
+
+   Example: `QuerySet.explain(comment="...", verbosity="...")`
+
+   Valid values for `verbosity` are `"queryPlanner"` (default),
+   `"executionStats"`, and `"allPlansExecution"`.
+
 ## Known issues and limitations
 
 - The following `QuerySet` methods aren't supported:

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -8,6 +8,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     has_json_object_function = False
     has_native_json_field = True
     supports_date_lookup_using_string = False
+    supports_explaining_query_execution = True
     supports_foreign_keys = False
     supports_ignore_conflicts = False
     supports_json_field_contains = False
@@ -53,9 +54,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         "expressions.tests.IterableLookupInnerExpressionsTests.test_expressions_in_lookups_join_choice",
         # Unexpected alias_refcount in alias_map.
         "queries.tests.Queries1Tests.test_order_by_tables",
-        # QuerySet.explain() not implemented:
-        # https://github.com/mongodb-labs/django-mongodb/issues/28
-        "queries.test_explain.ExplainUnsupportedTests.test_message",
         # The $sum aggregation returns 0 instead of None for null.
         "aggregation.test_filter_argument.FilteredAggregateTests.test_plain_annotate",
         "aggregation.tests.AggregateTestCase.test_aggregation_default_passed_another_aggregate",

--- a/django_mongodb/operations.py
+++ b/django_mongodb/operations.py
@@ -26,6 +26,7 @@ class DatabaseOperations(BaseDatabaseOperations):
         Combinable.BITOR: "bitOr",
         Combinable.BITXOR: "bitXor",
     }
+    explain_options = {"comment", "verbosity"}
 
     def adapt_datefield_value(self, value):
         """Store DateField as datetime."""
@@ -197,6 +198,19 @@ class DatabaseOperations(BaseDatabaseOperations):
         if field_kind == "DecimalField":
             value = self.adapt_decimalfield_value(value, field.max_digits, field.decimal_places)
         return value
+
+    def explain_query_prefix(self, format=None, **options):
+        # Validate options.
+        validated_options = {}
+        if options:
+            for valid_option in self.explain_options:
+                value = options.pop(valid_option, None)
+                if value is not None:
+                    validated_options[valid_option] = value
+        # super() raises an error if any options are left after the valid ones
+        # are popped above.
+        super().explain_query_prefix(format, **options)
+        return validated_options
 
     """Django uses these methods to generate SQL queries before it generates MQL queries."""
 


### PR DESCRIPTION
Example output:
```python
>>> print(Question.objects.explain())
explainVersion: '1'
queryPlanner: {   'indexFilterSet': False,
    'maxIndexedAndSolutionsReached': False,
    'maxIndexedOrSolutionsReached': False,
    'maxScansToExplodeReached': False,
    'namespace': 'mysite.polls_question',
    'optimizedPipeline': True,
    'parsedQuery': {},
    'rejectedPlans': [],
    'winningPlan': {'stage': 'EOF'}}
executionStats: {   'allPlansExecution': [],
    'executionStages': {   'advanced': 0,
                           'executionTimeMillisEstimate': 0,
                           'isEOF': 1,
                           'nReturned': 0,
                           'needTime': 0,
                           'needYield': 0,
                           'restoreState': 0,
                           'saveState': 0,
                           'stage': 'EOF',
                           'works': 1},
    'executionSuccess': True,
    'executionTimeMillis': 0,
    'nReturned': 0,
    'totalDocsExamined': 0,
    'totalKeysExamined': 0}
command: {   '$db': 'mysite',
    'aggregate': 'polls_question',
    'cursor': {},
    'pipeline': [{'$match': {'$expr': {}}}]}
serverInfo: {   'gitVersion': 'b6513ce0781db6818e24619e8a461eae90bc94fc',
    'host': 'westbrook',
    'port': 27017,
    'version': '7.0.12'}
serverParameters: {   'internalDocumentSourceGroupMaxMemoryBytes': 104857600,
    'internalDocumentSourceSetWindowFieldsMaxMemoryBytes': 104857600,
    'internalLookupStageIntermediateDocumentMaxSizeBytes': 104857600,
    'internalQueryFacetBufferSizeBytes': 104857600,
    'internalQueryFacetMaxOutputDocSizeBytes': 104857600,
    'internalQueryFrameworkControl': 'trySbeRestricted',
    'internalQueryMaxAddToSetBytes': 104857600,
    'internalQueryMaxBlockingSortMemoryUsageBytes': 104857600,
    'internalQueryProhibitBlockingMergeOnMongoS': 0}
```
Fixes #28 