### PR TITLE
separate query log message args with a comma

### DIFF
--- a/django_mongodb/utils.py
+++ b/django_mongodb/utils.py
@@ -42,7 +42,7 @@ class CollectionDebugWrapper:
 
     def log(self, op, duration, args, kwargs=None):
         msg = "(%.3f) %s"
-        args = " ".join(str(arg) for arg in args)
+        args = ", ".join(str(arg) for arg in args)
         operation = f"{self.collection.name}.{op}({args})"
         kwargs = {k: v for k, v in kwargs.items() if v}
         if kwargs:

--- a/django_mongodb/utils.py
+++ b/django_mongodb/utils.py
@@ -6,7 +6,6 @@ from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.utils import logger
 from django.utils.version import get_version_tuple
-from pymongo.cursor import Cursor
 
 
 def check_django_compatability():
@@ -41,12 +40,11 @@ class CollectionDebugWrapper:
         return duration, retval
 
     def log(self, op, duration, args, kwargs=None):
+        # If kwargs are used by any operations in the future, they must be
+        # added to this logging.
         msg = "(%.3f) %s"
         args = ", ".join(str(arg) for arg in args)
         operation = f"{self.collection.name}.{op}({args})"
-        kwargs = {k: v for k, v in kwargs.items() if v}
-        if kwargs:
-            operation += f"; kwargs={kwargs}"
         if len(settings.DATABASES) > 1:
             msg += f"; alias={self.db.alias}"
         self.db.queries_log.append(
@@ -62,19 +60,15 @@ class CollectionDebugWrapper:
             extra={
                 "duration": duration,
                 "sql": operation,
-                "kwargs": kwargs,
                 "alias": self.db.alias,
             },
         )
 
-    def find(self, *args, **kwargs):
-        return DebugCursor(self, self.collection, *args, **kwargs)
-
     def logging_wrapper(method):
         def wrapper(self, *args, **kwargs):
             func = getattr(self.collection, method)
-            # Collection.insert_one() mutates args[0] (the document) by adding
-            # the _id. deepcopy() to avoid logging that version.
+            # Collection.insert_many() mutates args (the documents) by adding
+            #  _id. deepcopy() to avoid logging that version.
             original_args = copy.deepcopy(args)
             duration, retval = self.profile_call(func, args, kwargs)
             self.log(method, duration, original_args, kwargs)
@@ -84,30 +78,8 @@ class CollectionDebugWrapper:
 
     # These are the operations that this backend uses.
     aggregate = logging_wrapper("aggregate")
-    count_documents = logging_wrapper("count_documents")
     insert_many = logging_wrapper("insert_many")
     delete_many = logging_wrapper("delete_many")
     update_many = logging_wrapper("update_many")
 
     del logging_wrapper
-
-
-class DebugCursor(Cursor):
-    def __init__(self, collection_wrapper, *args, **kwargs):
-        self.collection_wrapper = collection_wrapper
-        super().__init__(*args, **kwargs)
-
-    def _refresh(self):
-        super_method = super()._refresh
-        if self._Cursor__id is not None:
-            return super_method()
-        # self.__id is None: first time the .find() iterator is
-        # entered. find() profiling happens here.
-        duration, retval = self.collection_wrapper.profile_call(super_method)
-        kwargs = {
-            "limit": self._Cursor__limit,
-            "skip": self._Cursor__skip,
-            "sort": self._Cursor__ordering,
-        }
-        self.collection_wrapper.log("find", duration, [self._Cursor__spec], kwargs)
-        return retval


### PR DESCRIPTION
Also, remove obsolete bits of query logging.