### PR TITLE
add Django as a dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
+    "django>=5.0,<5.1",
     "pymongo>=4.6,<5.0",
 ]
 


### PR DESCRIPTION
This helps package management tools determine which version of django-mongodb is compatible with existing requirements.