### PR TITLE
add SchemaEditor support for create/delete model and rename table operations

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -111,6 +111,7 @@ jobs:
           or_lookups
           queries
           schema.tests.SchemaTests.test_creation_deletion
+          schema.tests.SchemaTests.test_db_table
           select_related
           select_related_onetoone
           select_related_regress

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -110,6 +110,7 @@ jobs:
           ordering
           or_lookups
           queries
+          schema.tests.SchemaTests.test_creation_deletion
           select_related
           select_related_onetoone
           select_related_regress

--- a/django_mongodb/schema.py
+++ b/django_mongodb/schema.py
@@ -3,10 +3,10 @@ from django.db.backends.base.schema import BaseDatabaseSchemaEditor
 
 class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def create_model(self, model):
-        pass
+        self.connection.database.create_collection(model._meta.db_table)
 
     def delete_model(self, model):
-        pass
+        self.connection.database[model._meta.db_table].drop()
 
     def add_field(self, model, field):
         pass

--- a/django_mongodb/schema.py
+++ b/django_mongodb/schema.py
@@ -5,6 +5,9 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def create_model(self, model):
         pass
 
+    def delete_model(self, model):
+        pass
+
     def add_field(self, model, field):
         pass
 
@@ -14,11 +17,26 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def remove_field(self, model, field):
         pass
 
+    def alter_index_together(self, model, old_index_together, new_index_together):
+        pass
+
     def alter_unique_together(self, model, old_unique_together, new_unique_together):
         pass
 
     def add_index(self, model, index):
         pass
 
+    def rename_index(self, model, old_index, new_index):
+        pass
+
     def remove_index(self, model, index):
+        pass
+
+    def add_constraint(self, model, constraint):
+        pass
+
+    def remove_constraint(self, model, constraint):
+        pass
+
+    def alter_db_table(self, model, old_db_table, new_db_table):
         pass

--- a/django_mongodb/schema.py
+++ b/django_mongodb/schema.py
@@ -39,4 +39,4 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
         pass
 
     def alter_db_table(self, model, old_db_table, new_db_table):
-        pass
+        self.connection.database[old_db_table].rename(new_db_table)


### PR DESCRIPTION
While implementing schema operations, `tests/schema/tests.py` in the Django fork will be heavily customized.