### PR TITLE
add debug logging for SchemaEditor operations

### DIFF
--- a/django_mongodb/base.py
+++ b/django_mongodb/base.py
@@ -12,7 +12,7 @@ from .introspection import DatabaseIntrospection
 from .operations import DatabaseOperations
 from .query_utils import regex_match
 from .schema import DatabaseSchemaEditor
-from .utils import CollectionDebugWrapper
+from .utils import OperationDebugWrapper
 
 
 class Cursor:
@@ -137,8 +137,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
     def get_collection(self, name, **kwargs):
         collection = Collection(self.database, name, **kwargs)
         if self.queries_logged:
-            collection = CollectionDebugWrapper(collection, self)
+            collection = OperationDebugWrapper(self, collection)
         return collection
+
+    def get_database(self):
+        if self.queries_logged:
+            return OperationDebugWrapper(self)
+        return self.database
 
     def __getattr__(self, attr):
         """

--- a/django_mongodb/schema.py
+++ b/django_mongodb/schema.py
@@ -7,9 +7,12 @@ class DatabaseSchemaEditor(BaseDatabaseSchemaEditor):
     def get_collection(self, name):
         return self.connection.get_collection(name)
 
+    def get_database(self):
+        return self.connection.get_database()
+
     @wrap_database_errors
     def create_model(self, model):
-        self.connection.database.create_collection(model._meta.db_table)
+        self.get_database().create_collection(model._meta.db_table)
         # Make implicit M2M tables.
         for field in model._meta.local_many_to_many:
             if field.remote_field.through._meta.auto_created:

--- a/django_mongodb/utils.py
+++ b/django_mongodb/utils.py
@@ -46,7 +46,7 @@ class OperationDebugWrapper:
         # If kwargs are used by any operations in the future, they must be
         # added to this logging.
         msg = "(%.3f) %s"
-        args = ", ".join(str(arg) for arg in args)
+        args = ", ".join(repr(arg) for arg in args)
         operation = f"db.{self.collection_name}{op}({args})"
         if len(settings.DATABASES) > 1:
             msg += f"; alias={self.db.alias}"

--- a/django_mongodb/utils.py
+++ b/django_mongodb/utils.py
@@ -78,8 +78,10 @@ class CollectionDebugWrapper:
 
     # These are the operations that this backend uses.
     aggregate = logging_wrapper("aggregate")
+    drop = logging_wrapper("drop")
     insert_many = logging_wrapper("insert_many")
     delete_many = logging_wrapper("delete_many")
+    rename = logging_wrapper("rename")
     update_many = logging_wrapper("update_many")
 
     del logging_wrapper


### PR DESCRIPTION
example:
```
./tests/runtests.py --settings=test_mongo schema.tests.SchemaTests.test_rename --debug-sql
Testing against Django installed in '/home/tim/code/django/django' with up to 3 processes
Found 1 test(s).
Creating test database for alias 'default'...
System check identified no issues (0 silenced).
F
======================================================================
FAIL: test_rename (schema.tests.SchemaTests.test_rename)
Tests simple altering of fields
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/tim/code/django/django/test/utils.py", line 443, in inner
    return func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^
  File "/home/tim/code/django/tests/schema/tests.py", line 2408, in test_rename
    assert False
AssertionError

----------------------------------------------------------------------
(0.030) db.create_collection(schema_author);

ALIAS=DEFAULT (0.002) db.schema_author.insert_many([{'name': 'foo', 'height': None, 'weight': None, 'uuid': None}]);

ALIAS=DEFAULT (0.002) db.schema_author.update_many({}, {'$rename': {'name': 'display_name'}});

ALIAS=DEFAULT (0.001) db.schema_author.aggregate([{'$match': {'$expr': {}}}, {'$limit': 21}]);
```
`db.create_collection(...)` and  `db.schema_author.update_many({}, {'$rename': ....})` lines are new.