### PR TITLE
fix username/password authentication

### DIFF
--- a/django_mongodb/base.py
+++ b/django_mongodb/base.py
@@ -1,4 +1,3 @@
-from django.core.exceptions import ImproperlyConfigured
 from django.db.backends.base.base import BaseDatabaseWrapper
 from django.db.backends.signals import connection_created
 from pymongo.collection import Collection
@@ -161,16 +160,13 @@ class DatabaseWrapper(BaseDatabaseWrapper):
         self.connection = MongoClient(
             host=settings_dict["HOST"] or None,
             port=int(settings_dict["PORT"] or 27017),
+            username=settings_dict.get("USER"),
+            password=settings_dict.get("PASSWORD"),
             **settings_dict["OPTIONS"],
         )
         db_name = settings_dict["NAME"]
         if db_name:
             self.database = self.connection[db_name]
-
-        user = settings_dict["USER"]
-        password = settings_dict["PASSWORD"]
-        if user and password and not self.database.authenticate(user, password):
-            raise ImproperlyConfigured("Invalid username or password.")
 
         self.connected = True
         connection_created.send(sender=self.__class__, connection=self)


### PR DESCRIPTION
This PR updates the MongoDB connection logic in the Django MongoDB integration to be compatible with PyMongo 4.x. The old method of authenticating db via `self.database.authenticate(user, password)` has been removed, since it was deprecated and [fully removed in PyMongo 4.x.](https://pymongo.readthedocs.io/en/stable/migrate-to-pymongo4.html#database-authenticate-and-database-logout-are-removed) 

### Changes Made:
- Refactored the `_connect()` method to utilize the predefined options to handle user credentials.
- Removed the deprecated `authenticate(user, password)` method.
- Added checks to prevent conflicting credentials between `USER/PASSWORD` (from settings) and `OPTIONS['username']` / `OPTIONS['password']`.
