### PR TITLE
fix SQLCompiler.collection_name crash on QuerySet.update() with MTI

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -91,6 +91,7 @@ jobs:
           migrations
           model_fields
           model_forms
+          model_inheritance_regress
           mutually_referential
           nested_foreign_keys
           null_fk

--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -673,6 +673,10 @@ class SQLInsertCompiler(SQLCompiler):
         inserted_ids = self.collection.insert_many(docs).inserted_ids
         return inserted_ids if returning_fields else []
 
+    @cached_property
+    def collection_name(self):
+        return self.query.get_meta().db_table
+
 
 class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
     def execute_sql(self, result_type=MULTI):
@@ -689,6 +693,10 @@ class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
 
     def get_where(self):
         return self.query.where
+
+    @cached_property
+    def collection_name(self):
+        return self.query.base_table
 
 
 class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
@@ -753,6 +761,10 @@ class SQLUpdateCompiler(compiler.SQLUpdateCompiler, SQLCompiler):
 
     def get_where(self):
         return self.query.where
+
+    @cached_property
+    def collection_name(self):
+        return self.query.base_table
 
 
 class SQLAggregateCompiler(SQLCompiler):

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -105,6 +105,9 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://github.com/mongodb-labs/django-mongodb/issues/161
         "queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup",
         "queries.tests.ValuesSubqueryTests.test_values_in_subquery",
+        # SQLCompiler.collection_name raises StopIteration
+        "model_inheritance_regress.tests.ModelInheritanceTest.test_mti_update_grand_parent_through_child",
+        "model_inheritance_regress.tests.ModelInheritanceTest.test_mti_update_parent_through_child",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {
@@ -266,6 +269,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "datetimes.tests.DateTimesTests.test_datetimes_has_lazy_iterator",
             "datetimes.tests.DateTimesTests.test_datetimes_returns_available_dates_for_given_scope_and_given_field",
             "datetimes.tests.DateTimesTests.test_related_model_traverse",
+            "model_inheritance_regress.tests.ModelInheritanceTest.test_issue_7105",
             "queries.tests.Queries1Tests.test_ticket7155",
             "queries.tests.Queries1Tests.test_tickets_7087_12242",
             "timezones.tests.LegacyDatabaseTests.test_query_datetimes",

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -105,9 +105,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://github.com/mongodb-labs/django-mongodb/issues/161
         "queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup",
         "queries.tests.ValuesSubqueryTests.test_values_in_subquery",
-        # SQLCompiler.collection_name raises StopIteration
-        "model_inheritance_regress.tests.ModelInheritanceTest.test_mti_update_grand_parent_through_child",
-        "model_inheritance_regress.tests.ModelInheritanceTest.test_mti_update_parent_through_child",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {


### PR DESCRIPTION
fixes #165