### PR TITLE
make ObjectIdAutoField.to_python() accept integers as strings

### DIFF
--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -93,6 +93,7 @@ jobs:
           migrations
           model_fields
           model_forms
+          model_formsets
           model_inheritance_regress
           mutually_referential
           nested_foreign_keys

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -82,8 +82,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://github.com/mongodb-labs/django-mongodb/issues/161
         "queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup",
         "queries.tests.ValuesSubqueryTests.test_values_in_subquery",
-        # ObjectIdAutoField.to_python() doesn't accept integers as strings.
-        "model_formsets.tests.ModelFormsetTest.test_inline_formsets_with_custom_save_method",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -82,6 +82,8 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         # https://github.com/mongodb-labs/django-mongodb/issues/161
         "queries.tests.RelatedLookupTypeTests.test_values_queryset_lookup",
         "queries.tests.ValuesSubqueryTests.test_values_in_subquery",
+        # ObjectIdAutoField.to_python() doesn't accept integers as strings.
+        "model_formsets.tests.ModelFormsetTest.test_inline_formsets_with_custom_save_method",
     }
     # $bitAnd, #bitOr, and $bitXor are new in MongoDB 6.3.
     _django_test_expected_failures_bitwise = {

--- a/django_mongodb/fields/auto.py
+++ b/django_mongodb/fields/auto.py
@@ -40,11 +40,14 @@ class ObjectIdAutoField(AutoField):
         try:
             return ObjectId(value)
         except errors.InvalidId:
-            raise exceptions.ValidationError(
-                self.error_messages["invalid"],
-                code="invalid",
-                params={"value": value},
-            ) from None
+            try:
+                return int(value)
+            except ValueError:
+                raise exceptions.ValidationError(
+                    self.error_messages["invalid"],
+                    code="invalid",
+                    params={"value": value},
+                ) from None
 
     @cached_property
     def validators(self):

--- a/tests/model_fields_/test_autofield.py
+++ b/tests/model_fields_/test_autofield.py
@@ -1,0 +1,9 @@
+from django.test import SimpleTestCase
+
+from django_mongodb.fields import ObjectIdAutoField
+
+
+class MethodTests(SimpleTestCase):
+    def test_to_python(self):
+        f = ObjectIdAutoField()
+        self.assertEqual(f.to_python("1"), 1)


### PR DESCRIPTION
There are at least two places in Django where `Field.to_python()` processes uncoerced form data, `BaseModelFormSet._construct_form()` and `ModelAdmin.get_object()`.