### PR TITLE
made QuerySet.bulk_create() set pk on created model instances

### DIFF
--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -677,13 +677,13 @@ class SQLInsertCompiler(SQLCompiler):
 
                 field_values[field.column] = value
             objs.append(field_values)
-        return [self.insert(objs, returning_fields=returning_fields)]
+        return self.insert(objs, returning_fields=returning_fields)
 
     @wrap_database_errors
     def insert(self, docs, returning_fields=None):
         """Store a list of documents using field columns as element names."""
         inserted_ids = self.collection.insert_many(docs).inserted_ids
-        return inserted_ids if returning_fields else []
+        return [(x,) for x in inserted_ids] if returning_fields else []
 
     @cached_property
     def collection_name(self):

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -10,6 +10,7 @@ class DatabaseFeatures(BaseDatabaseFeatures):
     allows_multiple_constraints_on_same_fields = False
     can_create_inline_fk = False
     can_introspect_foreign_keys = False
+    can_return_rows_from_bulk_insert = True
     greatest_least_ignores_nulls = True
     has_json_object_function = False
     has_native_json_field = True

--- a/django_mongodb/features.py
+++ b/django_mongodb/features.py
@@ -197,7 +197,6 @@ class DatabaseFeatures(BaseDatabaseFeatures):
         },
         "AutoField not supported.": {
             "bulk_create.tests.BulkCreateTests.test_bulk_insert_nullable_fields",
-            "custom_pk.tests.CustomPKTests.test_auto_field_subclass_create",
             "introspection.tests.IntrospectionTests.test_sequence_list",
             "lookup.tests.LookupTests.test_filter_by_reverse_related_field_transform",
             "lookup.tests.LookupTests.test_in_ignore_none_with_unhashable_items",
@@ -211,6 +210,12 @@ class DatabaseFeatures(BaseDatabaseFeatures):
             "model_fields.test_autofield.BigAutoFieldTests",
             "model_fields.test_autofield.SmallAutoFieldTests",
             "queries.tests.TestInvalidValuesRelation.test_invalid_values",
+        },
+        "Converters aren't run on returning fields from insert.": {
+            # Unsure this is needed for this backend. Can implement by request.
+            # https://github.com/django/django/commit/d9de74141e8a920940f1b91ed0a3ccb835b55729
+            "custom_pk.tests.CustomPKTests.test_auto_field_subclass_bulk_create",
+            "custom_pk.tests.CustomPKTests.test_auto_field_subclass_create",
         },
         "MongoDB does not enforce PositiveIntegerField constraint.": {
             "model_fields.test_integerfield.PositiveIntegerFieldTests.test_negative_values",


### PR DESCRIPTION
This covered by tests in Django's test suite that will no longer be skipped when `can_return_rows_from_bulk_insert` is set to True.