### PR TITLE
fix QuerySet.delete() crash when it raises EmptyResultSet

### DIFF
--- a/django_mongodb/compiler.py
+++ b/django_mongodb/compiler.py
@@ -693,7 +693,13 @@ class SQLInsertCompiler(SQLCompiler):
 class SQLDeleteCompiler(compiler.SQLDeleteCompiler, SQLCompiler):
     def execute_sql(self, result_type=MULTI):
         cursor = Cursor()
-        cursor.rowcount = self.build_query().delete()
+        try:
+            query = self.build_query()
+        except EmptyResultSet:
+            rowcount = 0
+        else:
+            rowcount = query.delete()
+        cursor.rowcount = rowcount
         return cursor
 
     def check_query(self):


### PR DESCRIPTION
Surprisingly, Django's test suite didn't have a suitable regression test, so I'll send this upstream:
```diff
diff --git a/tests/delete/tests.py b/tests/delete/tests.py
index 01228631f4..2d2c42dfb1 100644
--- a/tests/delete/tests.py
+++ b/tests/delete/tests.py
@@ -794,6 +794,14 @@ class FastDeleteTests(TestCase):
             )
         self.assertIs(Base.objects.exists(), False)
 
+    def test_fast_delete_empty_result_set(self):
+        User.objects.create()
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                User.objects.filter(pk__in=[]).delete(),
+                (0, {}),
+            )
+
     def test_fast_delete_full_match(self):
         avatar = Avatar.objects.create(desc="bar")
         User.objects.create(avatar=avatar)
```