### PR TITLE
Pin zizmorcore/zizmor-action to v0.1.2

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,4 +18,4 @@ jobs:
         with:
           persist-credentials: false
       - name: Run zizmor
-        uses: zizmorcore/zizmor-action@383d31df2eb66a2f42db98c9654bdc73231f3e3a
+        uses: zizmorcore/zizmor-action@5ca5fc7a4779c5263a3ffa0e1f693009994446d1 # v0.1.2


### PR DESCRIPTION
I copied the unpinned version from pymongo, but maybe now that there's [a recent release](https://github.com/zizmorcore/zizmor-action/releases) (5 days ago), we don't need that anymore? 