### PR TITLE
Move known-issues from topics to refs

### DIFF
--- a/docs/source/contents.rst
+++ b/docs/source/contents.rst
@@ -14,6 +14,7 @@ Table of contents
     ref/index
     howto/index
     faq
+    known-issues
     releases/index
     internals
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -14,7 +14,7 @@ First steps
 - :doc:`Installation <intro/install>`
 - :doc:`Configuring a project <intro/configure>`
 - :doc:`howto/contrib-apps`
-- :doc:`topics/known-issues`
+- :doc:`known-issues`
 
 Getting help
 ============
@@ -24,7 +24,8 @@ Having trouble? We’d like to help!
 - Try the :doc:`faq` – it’s got answers to many common questions.
 
 - Looking for specific information? Try the :ref:`genindex`, :ref:`modindex`,
-  or the detailed :doc:`table of contents <contents>`.
+  :doc:`topics section <topics/index>` or detailed :doc:`table of contents
+  <contents>`.
 
 - The :doc:`howto/index` section has step-by-step guides for common tasks.
 
@@ -74,5 +75,6 @@ Miscellaneous
     ref/index
     howto/index
     faq
+    known-issues
     releases/index
     internals

--- a/docs/source/known-issues.rst
+++ b/docs/source/known-issues.rst
@@ -1,6 +1,6 @@
-============================
-Known issues and limitations
-============================
+============
+Known issues
+============
 
 This document summarizes some known issues and limitations of this library.
 If you notice an issue not listed, use the :ref:`issue-tracker` to report a bug

--- a/docs/source/topics/index.rst
+++ b/docs/source/topics/index.rst
@@ -10,4 +10,3 @@ know:
 
    embedded-models
    transactions
-   known-issues


### PR DESCRIPTION
This PR addresses two issues with the documentation I've noticed:

- Move known-issues to the top level
  - In addition to linking from the index, move to the top level for maximum discoverability
  - Remove from topics section due to it's cross-topic relevance.
- Add topics section to bullet point about finding specific topics
  - Prior to this PR the topics section was only navigable from the sidebar menu and from the index under the model reference