### PR TITLE
INTPYTHON-529 Add serialization support for embedded model fields

### DIFF
--- a/django_mongodb_backend/fields/embedded_model.py
+++ b/django_mongodb_backend/fields/embedded_model.py
@@ -2,6 +2,7 @@ import difflib
 
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.serializers import register_field_serializer
 from django.db import models
 from django.db.models.fields.related import lazy_related_operation
 from django.db.models.lookups import Transform
@@ -9,7 +10,13 @@ from django.utils.functional import cached_property
 
 from django_mongodb_backend import forms
 
-from .utils import serialize_model_reference
+from .utils import (
+    deserialize_from_python,
+    deserialize_from_xml,
+    serialize_model_reference,
+    serialize_to_python,
+    serialize_to_xml,
+)
 
 
 class EmbeddedModelField(models.Field):
@@ -158,6 +165,35 @@ class EmbeddedModelField(models.Field):
                 **kwargs,
             }
         )
+
+
+@register_field_serializer("python", EmbeddedModelField)
+class PythonSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value = field.value_from_object(obj)
+        if value is None:
+            return None
+        return serialize_to_python(value, serializer)
+
+    @classmethod
+    def deserialize(cls, field, value, deserializer):
+        if value is None:
+            return None
+        return deserialize_from_python(value, deserializer, model=field.embedded_model)
+
+
+@register_field_serializer("xml", EmbeddedModelField)
+class XMLSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value = field.value_from_object(obj)
+        serialize_to_xml(value, serializer)
+        return ""
+
+    @classmethod
+    def deserialize(cls, field, field_node, deserializer):
+        return deserialize_from_xml(field_node, deserializer, model=field.embedded_model)[0]
 
 
 class EmbeddedModelTransform(Transform):

--- a/django_mongodb_backend/fields/embedded_model_array.py
+++ b/django_mongodb_backend/fields/embedded_model_array.py
@@ -1,6 +1,7 @@
 import difflib
 
 from django.core.exceptions import FieldDoesNotExist
+from django.core.serializers import register_field_serializer
 from django.db.models import Field, lookups
 from django.db.models.expressions import Col
 from django.db.models.fields.related import lazy_related_operation
@@ -13,7 +14,12 @@ from django_mongodb_backend.fields.array import ArrayField, ArrayLenTransform
 from django_mongodb_backend.query_utils import process_lhs, process_rhs
 
 from .mixins import NoEncryptedEmbeddedFieldsMixin
-from .utils import serialize_model_reference
+from .utils import (
+    deserialize_from_python,
+    deserialize_from_xml,
+    serialize_model_reference,
+    serialize_to_python,
+)
 
 
 class EmbeddedModelArrayField(NoEncryptedEmbeddedFieldsMixin, ArrayField):
@@ -93,6 +99,44 @@ class EmbeddedModelArrayField(NoEncryptedEmbeddedFieldsMixin, ArrayField):
                 )
 
         return EmbeddedModelArrayFieldLookups
+
+
+@register_field_serializer("python", EmbeddedModelArrayField)
+class PythonSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value = field.value_from_object(obj)
+        if value is None:
+            return None
+        return [serialize_to_python(val, serializer) for val in value]
+
+    @classmethod
+    def deserialize(cls, field, value, deserializer):
+        if value is None:
+            return None
+        return [
+            deserialize_from_python(val, deserializer, model=field.embedded_model) for val in value
+        ]
+
+
+@register_field_serializer("xml", EmbeddedModelArrayField)
+class XMLSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value_list = field.value_from_object(obj)
+        if value_list is None:
+            serializer.xml.addQuickElement("None")
+        else:
+            for value in value_list:
+                serializer.start_object(value)
+                for field in value._meta.local_fields:
+                    serializer.handle_field(value, field)
+                serializer.end_object(value)
+        return ""
+
+    @classmethod
+    def deserialize(cls, field, field_node, deserializer):
+        return deserialize_from_xml(field_node, deserializer, model=field.embedded_model)
 
 
 class _EmbeddedModelArrayOutputField(ArrayField):

--- a/django_mongodb_backend/fields/polymorphic_embedded_model.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model.py
@@ -2,11 +2,19 @@ import contextlib
 
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ValidationError
+from django.core.serializers import register_field_serializer
 from django.db import models
 from django.db.models.fields.related import lazy_related_operation
 
 from .embedded_model import EmbeddedModelTransformFactory
-from .utils import get_mongodb_connection, serialize_model_reference
+from .utils import (
+    deserialize_from_python,
+    deserialize_from_xml,
+    get_mongodb_connection,
+    serialize_model_reference,
+    serialize_to_python,
+    serialize_to_xml,
+)
 
 
 class PolymorphicEmbeddedModelField(models.Field):
@@ -187,4 +195,35 @@ class PolymorphicEmbeddedModelField(models.Field):
         raise NotImplementedError("PolymorphicEmbeddedModelField does not support forms.")
 
     def _get_model_from_label(self, label):
-        return next(model for model in self.embedded_models if model._meta.label == label)
+        return next(
+            model for model in self.embedded_models if model._meta.label.lower() == label.lower()
+        )
+
+
+@register_field_serializer("python", PolymorphicEmbeddedModelField)
+class PythonSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value = field.value_from_object(obj)
+        if value is None:
+            return None
+        return serialize_to_python(value, serializer, polymorphic=True)
+
+    @classmethod
+    def deserialize(cls, field, value, deserializer):
+        if value is None:
+            return None
+        return deserialize_from_python(value, deserializer, field=field)
+
+
+@register_field_serializer("xml", PolymorphicEmbeddedModelField)
+class XMLSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value = field.value_from_object(obj)
+        serialize_to_xml(value, serializer)
+        return ""
+
+    @classmethod
+    def deserialize(cls, field, field_node, deserializer):
+        return deserialize_from_xml(field_node, deserializer, field=field)[0]

--- a/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
@@ -1,6 +1,7 @@
 import contextlib
 
 from django.core.exceptions import FieldDoesNotExist
+from django.core.serializers import register_field_serializer
 from django.db.models.expressions import Col
 from django.db.models.fields.related import lazy_related_operation
 from django.db.models.lookups import Lookup, Transform
@@ -11,7 +12,12 @@ from .embedded_model_array import (
     EmbeddedModelArrayFieldTransform,
     EmbeddedModelArrayFieldTransformFactory,
 )
-from .utils import serialize_model_reference
+from .utils import (
+    deserialize_from_python,
+    deserialize_from_xml,
+    serialize_model_reference,
+    serialize_to_python,
+)
 
 
 class PolymorphicEmbeddedModelArrayField(ArrayField):
@@ -124,3 +130,39 @@ class PolymorphicArrayFieldTransform(EmbeddedModelArrayFieldTransform):
 class PolymorphicArrayFieldTransformFactory(EmbeddedModelArrayFieldTransformFactory):
     def __call__(self, *args, **kwargs):
         return PolymorphicArrayFieldTransform(self.field, *args, **kwargs)
+
+
+@register_field_serializer("python", PolymorphicEmbeddedModelArrayField)
+class PythonSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value = field.value_from_object(obj)
+        if value is None:
+            return None
+        return [serialize_to_python(val, serializer, polymorphic=True) for val in value]
+
+    @classmethod
+    def deserialize(cls, field, value, deserializer):
+        if value is None:
+            return None
+        return [deserialize_from_python(val, deserializer, field=field) for val in value]
+
+
+@register_field_serializer("xml", PolymorphicEmbeddedModelArrayField)
+class XMLSerializer:
+    @classmethod
+    def serialize(cls, field, obj, serializer):
+        value_list = field.value_from_object(obj)
+        if value_list is None:
+            serializer.xml.addQuickElement("None")
+        else:
+            for value in value_list:
+                serializer.start_object(value)
+                for field in value._meta.local_fields:
+                    serializer.handle_field(value, field)
+                serializer.end_object(value)
+        return ""
+
+    @classmethod
+    def deserialize(cls, field, field_node, deserializer):
+        return deserialize_from_xml(field_node, deserializer, field=field)

--- a/django_mongodb_backend/fields/utils.py
+++ b/django_mongodb_backend/fields/utils.py
@@ -1,4 +1,75 @@
+from django.core.serializers.xml_serializer import getChildrenByTagName
 from django.db import connections
+
+
+def serialize_to_python(obj, serializer, *, polymorphic=False):
+    data = {field.name: serializer.serialize_field(field, obj) for field in obj._meta.local_fields}
+    if polymorphic:
+        data["_label"] = obj._meta.label
+    return data
+
+
+def deserialize_from_python(
+    value,
+    deserializer,
+    *,
+    field=None,
+    model=None,
+):
+    """
+    Deserialize `value` (a dictionary) into a model instance.
+
+    For homogeneous embedded model fields, the model class is specified by the
+    `model` kwarg.
+    """
+    if model is None:
+        # For polymorphic embedded model fields, the model class is specified
+        # by the  "_label" in the `value`.
+        # field._get_model_from_label().
+        label = value.pop("_label")
+        # In which case `field` must be specified so that the model class
+        # can be looked up.
+        model = field._get_model_from_label(label)
+    subdata = {}
+    for subfield_name, subvalue in value.items():
+        subfield = model._meta.get_field(subfield_name)
+        subdata[subfield.name] = deserializer.deserialize_field(subfield, subvalue, deserializer)
+    return model(**subdata)
+
+
+def serialize_to_xml(obj, serializer):
+    serializer.start_object(obj)
+    if obj is None:
+        serializer.xml.addQuickElement("None")
+    else:
+        for field in obj._meta.local_fields:
+            serializer.handle_field(obj, field)
+    serializer.end_object(obj)
+
+
+def deserialize_from_xml(field_node, deserializer, *, field=None, model=None):
+    """
+    Deserialize `field_node` into a model instance.
+
+    For homogeneous embedded model fields, the model class is specified by the
+    `model` kwarg.
+    """
+    objs = getChildrenByTagName(field_node, "object")
+    data = {}
+    instances = []
+    for obj in objs:
+        if model is None:
+            model = field._get_model_from_label(obj.getAttribute("model"))
+        for subfield_node in getChildrenByTagName(obj, "field"):
+            field_name = subfield_node.getAttribute("name")
+            subfield = model._meta.get_field(field_name)
+            if getChildrenByTagName(subfield_node, "None"):
+                value = None
+            else:
+                value = deserializer.deserialize_field(subfield, subfield_node, deserializer)
+            data[field_name] = value
+        instances.append(model(**data))
+    return instances
 
 
 def get_mongodb_connection():

--- a/tests/serializers_/models.py
+++ b/tests/serializers_/models.py
@@ -1,0 +1,98 @@
+from django.db import models
+
+from django_mongodb_backend.fields import (
+    EmbeddedModelArrayField,
+    EmbeddedModelField,
+    PolymorphicEmbeddedModelArrayField,
+    PolymorphicEmbeddedModelField,
+)
+from django_mongodb_backend.models import EmbeddedModel
+
+
+class Address(EmbeddedModel):
+    city = models.CharField(max_length=20)
+    state = models.CharField(max_length=2)
+    zip_code = models.IntegerField()
+
+
+class Author(EmbeddedModel):
+    name = models.CharField(max_length=10)
+    age = models.IntegerField()
+    address = EmbeddedModelField(Address)
+
+
+class Book(models.Model):
+    name = models.CharField(max_length=100)
+    author = EmbeddedModelField(Author)
+
+
+# EmbeddedModelArrayField
+class Movie(models.Model):
+    title = models.CharField(max_length=255)
+    reviews = EmbeddedModelArrayField("Review", null=True)
+
+    def __str__(self):
+        return self.title
+
+
+class Review(EmbeddedModel):
+    title = models.CharField(max_length=255, db_column="title_")
+    rating = models.DecimalField(max_digits=6, decimal_places=1)
+
+    def __str__(self):
+        return self.title
+
+
+# PolymorphicEmbeddedModelField
+class Person(models.Model):
+    name = models.CharField(max_length=100)
+    pet = PolymorphicEmbeddedModelField(("Dog", "Cat"), blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Dog(EmbeddedModel):
+    name = models.CharField(max_length=100)
+    barks = models.BooleanField(default=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    favorite_toy = PolymorphicEmbeddedModelField(["Bone"], blank=True, null=True)
+    toys = PolymorphicEmbeddedModelArrayField(["Bone"], blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Cat(EmbeddedModel):
+    name = models.CharField(max_length=100, db_column="name_")
+    purs = models.BooleanField(default=True)
+    weight = models.DecimalField(max_digits=4, decimal_places=2, blank=True, null=True)
+    favorite_toy = PolymorphicEmbeddedModelField(["Mouse"], blank=True, null=True)
+    toys = PolymorphicEmbeddedModelArrayField(["Mouse"], blank=True, null=True)
+
+    def __str__(self):
+        return self.name
+
+
+class Bone(EmbeddedModel):
+    brand = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.brand
+
+
+class Mouse(EmbeddedModel):
+    manufacturer = models.CharField(max_length=100)
+
+    def __str__(self):
+        return self.manufacturer
+
+
+# PolymorphicEmbeddedModelArrayField
+class Owner(models.Model):
+    name = models.CharField(max_length=100)
+    pets = PolymorphicEmbeddedModelArrayField(("Dog", "Cat"), blank=True, null=True)
+
+    def __str__(self):
+        return self.name

--- a/tests/serializers_/test_embedded_model.py
+++ b/tests/serializers_/test_embedded_model.py
@@ -1,0 +1,567 @@
+from bson import ObjectId
+from django.core import serializers
+from django.test import TestCase
+
+from .models import Address, Author, Book, Cat, Dog, Movie, Owner, Person, Review
+
+
+class SerializationTests:
+    maxDiff = None
+
+    def test_embedded_model_field(self):
+        objects = [
+            Book(
+                id=ObjectId("000000000000000000000001"),
+                name="Hamlet",
+                author=Author(name="Shakespeare", age=55, address=Address(city="NYC", state="NY")),
+            ),
+        ]
+        serialized_data = serializers.serialize(self.serialization_format, objects, indent=2)
+        self.assertEqual(serialized_data, self.expected_data["embedded_model_field"])
+        for obj in serializers.deserialize(self.serialization_format, serialized_data):
+            obj.save()
+        book = Book.objects.get()
+        self.assertEqual(book.name, "Hamlet")
+        self.assertEqual(book.author.name, "Shakespeare")
+        self.assertEqual(book.author.address.city, "NYC")
+
+    def test_embedded_model_field_null(self):
+        serialized_data = serializers.serialize(
+            self.serialization_format, [Book(author=None)], indent=2
+        )
+        self.assertEqual(serialized_data, self.expected_data["embedded_model_field_null"])
+        objs = serializers.deserialize(self.serialization_format, serialized_data)
+        self.assertIsNone(next(iter(objs)).object.author, None)
+
+    def test_embedded_model_array_field(self):
+        reviews = [
+            Review(title="The best", rating=10),
+            Review(title="Mediocre", rating=5),
+            Review(title="Horrible", rating=1),
+        ]
+        objects = [
+            Movie(id=ObjectId("000000000000000000000001"), title="Lion King", reviews=reviews)
+        ]
+        serialized_data = serializers.serialize(self.serialization_format, objects, indent=2)
+        self.assertEqual(serialized_data, self.expected_data["embedded_model_array_field"])
+        for obj in serializers.deserialize(self.serialization_format, serialized_data):
+            obj.save()
+        movie = Movie.objects.get()
+        self.assertEqual(movie.title, "Lion King")
+        self.assertEqual(movie.reviews[0].title, "The best")
+        self.assertEqual(movie.reviews[0].rating, 10)
+        self.assertEqual(movie.reviews[2].title, "Horrible")
+        self.assertEqual(movie.reviews[2].rating, 1)
+
+    def test_embedded_model_array_field_null(self):
+        serialized_data = serializers.serialize(
+            self.serialization_format, [Movie(reviews=None)], indent=2
+        )
+        self.assertEqual(serialized_data, self.expected_data["embedded_model_array_field_null"])
+        objs = serializers.deserialize(self.serialization_format, serialized_data)
+        self.assertIsNone(next(iter(objs)).object.reviews, None)
+
+    def test_polymorphic_embedded_model_field(self):
+        objects = [
+            Person(id=ObjectId("000000000000000000000001"), name="Cliff", pet=Dog(name="Woofer")),
+            Person(id=ObjectId("000000000000000000000002"), name="Marla", pet=Cat(name="April")),
+        ]
+        serialized_data = serializers.serialize(self.serialization_format, objects, indent=2)
+        self.assertEqual(serialized_data, self.expected_data["polymorphic_embedded_model_field"])
+        for obj in serializers.deserialize(self.serialization_format, serialized_data):
+            obj.save()
+        cliff = Person.objects.get(name="Cliff")
+        self.assertIsInstance(cliff.pet, Dog)
+        self.assertEqual(cliff.pet.name, "Woofer")
+        marla = Person.objects.get(name="Marla")
+        self.assertIsInstance(marla.pet, Cat)
+        self.assertEqual(marla.pet.name, "April")
+
+    def test_polymorphic_embedded_model_field_null(self):
+        serialized_data = serializers.serialize(
+            self.serialization_format, [Person(pet=None)], indent=2
+        )
+        self.assertEqual(
+            serialized_data,
+            self.expected_data["polymorphic_embedded_model_field_null"],
+        )
+        objs = serializers.deserialize(self.serialization_format, serialized_data)
+        self.assertIsNone(next(iter(objs)).object.pet, None)
+
+    def test_polymorphic_embedded_model_array_field(self):
+        objects = [
+            Owner(
+                id=ObjectId("000000000000000000000001"),
+                name="Cliff",
+                pets=[Dog(name="Woofer"), Dog(name="Joey")],
+            ),
+            Owner(id=ObjectId("000000000000000000000002"), name="Marla", pets=[Cat(name="April")]),
+        ]
+        serialized_data = serializers.serialize(self.serialization_format, objects, indent=2)
+        self.assertEqual(
+            serialized_data,
+            self.expected_data["polymorphic_embedded_model_array_field"],
+        )
+        for obj in serializers.deserialize(self.serialization_format, serialized_data):
+            obj.save()
+        cliff = Owner.objects.get(name="Cliff")
+        self.assertIsInstance(cliff.pets[0], Dog)
+        self.assertEqual(cliff.pets[0].name, "Woofer")
+        marla = Owner.objects.get(name="Marla")
+        self.assertIsInstance(marla.pets[0], Cat)
+        self.assertEqual(marla.pets[0].name, "April")
+
+    def test_polymorphic_embedded_model_array_field_null(self):
+        serialized_data = serializers.serialize(
+            self.serialization_format, [Owner(pets=None)], indent=2
+        )
+        self.assertEqual(
+            serialized_data,
+            self.expected_data["polymorphic_embedded_model_array_field_null"],
+        )
+        objs = serializers.deserialize(self.serialization_format, serialized_data)
+        self.assertIsNone(next(iter(objs)).object.pets, None)
+
+
+class JSONSerializerTests(SerializationTests, TestCase):
+    serialization_format = "json"
+    expected_data = {
+        "embedded_model_field": """[
+{
+  "model": "serializers_.book",
+  "pk": "000000000000000000000001",
+  "fields": {
+    "name": "Hamlet",
+    "author": {
+      "id": null,
+      "name": "Shakespeare",
+      "age": 55,
+      "address": {
+        "id": null,
+        "city": "NYC",
+        "state": "NY",
+        "zip_code": null
+      }
+    }
+  }
+}
+]
+""",
+        "embedded_model_field_null": """[
+{
+  "model": "serializers_.book",
+  "pk": null,
+  "fields": {
+    "name": "",
+    "author": null
+  }
+}
+]
+""",
+        "embedded_model_array_field": """[
+{
+  "model": "serializers_.movie",
+  "pk": "000000000000000000000001",
+  "fields": {
+    "title": "Lion King",
+    "reviews": [
+      {
+        "id": null,
+        "title": "The best",
+        "rating": 10
+      },
+      {
+        "id": null,
+        "title": "Mediocre",
+        "rating": 5
+      },
+      {
+        "id": null,
+        "title": "Horrible",
+        "rating": 1
+      }
+    ]
+  }
+}
+]
+""",
+        "embedded_model_array_field_null": """[
+{
+  "model": "serializers_.movie",
+  "pk": null,
+  "fields": {
+    "title": "",
+    "reviews": null
+  }
+}
+]
+""",
+        "polymorphic_embedded_model_field": """[
+{
+  "model": "serializers_.person",
+  "pk": "000000000000000000000001",
+  "fields": {
+    "name": "Cliff",
+    "pet": {
+      "id": null,
+      "name": "Woofer",
+      "barks": true,
+      "created_at": null,
+      "updated_at": null,
+      "favorite_toy": null,
+      "toys": null,
+      "_label": "serializers_.Dog"
+    }
+  }
+},
+{
+  "model": "serializers_.person",
+  "pk": "000000000000000000000002",
+  "fields": {
+    "name": "Marla",
+    "pet": {
+      "id": null,
+      "name": "April",
+      "purs": true,
+      "weight": null,
+      "favorite_toy": null,
+      "toys": null,
+      "_label": "serializers_.Cat"
+    }
+  }
+}
+]
+""",
+        "polymorphic_embedded_model_field_null": """[
+{
+  "model": "serializers_.person",
+  "pk": null,
+  "fields": {
+    "name": "",
+    "pet": null
+  }
+}
+]
+""",
+        "polymorphic_embedded_model_array_field": """[
+{
+  "model": "serializers_.owner",
+  "pk": "000000000000000000000001",
+  "fields": {
+    "name": "Cliff",
+    "pets": [
+      {
+        "id": null,
+        "name": "Woofer",
+        "barks": true,
+        "created_at": null,
+        "updated_at": null,
+        "favorite_toy": null,
+        "toys": null,
+        "_label": "serializers_.Dog"
+      },
+      {
+        "id": null,
+        "name": "Joey",
+        "barks": true,
+        "created_at": null,
+        "updated_at": null,
+        "favorite_toy": null,
+        "toys": null,
+        "_label": "serializers_.Dog"
+      }
+    ]
+  }
+},
+{
+  "model": "serializers_.owner",
+  "pk": "000000000000000000000002",
+  "fields": {
+    "name": "Marla",
+    "pets": [
+      {
+        "id": null,
+        "name": "April",
+        "purs": true,
+        "weight": null,
+        "favorite_toy": null,
+        "toys": null,
+        "_label": "serializers_.Cat"
+      }
+    ]
+  }
+}
+]
+""",
+        "polymorphic_embedded_model_array_field_null": """[
+{
+  "model": "serializers_.owner",
+  "pk": null,
+  "fields": {
+    "name": "",
+    "pets": null
+  }
+}
+]
+""",
+    }
+
+
+class XMLSerializerTests(SerializationTests, TestCase):
+    maxDiff = None
+    serialization_format = "xml"
+    expected_data = {
+        "embedded_model_field": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.book" pk="000000000000000000000001">
+    <field name="name" type="CharField">Hamlet</field>
+    <field name="author" type="EmbeddedModelField">
+      <object model="serializers_.author">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="name" type="CharField">Shakespeare</field>
+        <field name="age" type="IntegerField">55</field>
+        <field name="address" type="EmbeddedModelField">
+          <object model="serializers_.address">
+            <field name="id" type="ObjectIdAutoField"><None></None></field>
+            <field name="city" type="CharField">NYC</field>
+            <field name="state" type="CharField">NY</field>
+            <field name="zip_code" type="IntegerField"><None></None></field>
+          </object></field>
+      </object></field>
+  </object>
+</django-objects>""",
+        "embedded_model_field_null": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.book">
+    <field name="name" type="CharField"></field>
+    <field name="author" type="EmbeddedModelField"><None></None></field>
+  </object>
+</django-objects>""",
+        "embedded_model_array_field": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.movie" pk="000000000000000000000001">
+    <field name="title" type="CharField">Lion King</field>
+    <field name="reviews" type="EmbeddedModelArrayField">
+      <object model="serializers_.review">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="title" type="CharField">The best</field>
+        <field name="rating" type="DecimalField">10</field>
+      </object>
+      <object model="serializers_.review">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="title" type="CharField">Mediocre</field>
+        <field name="rating" type="DecimalField">5</field>
+      </object>
+      <object model="serializers_.review">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="title" type="CharField">Horrible</field>
+        <field name="rating" type="DecimalField">1</field>
+      </object></field>
+  </object>
+</django-objects>""",
+        "embedded_model_array_field_null": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.movie">
+    <field name="title" type="CharField"></field>
+    <field name="reviews" type="EmbeddedModelArrayField"><None></None></field>
+  </object>
+</django-objects>""",
+        "polymorphic_embedded_model_field": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.person" pk="000000000000000000000001">
+    <field name="name" type="CharField">Cliff</field>
+    <field name="pet" type="PolymorphicEmbeddedModelField">
+      <object model="serializers_.dog">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="name" type="CharField">Woofer</field>
+        <field name="barks" type="BooleanField">True</field>
+        <field name="created_at" type="DateTimeField"><None></None></field>
+        <field name="updated_at" type="DateTimeField"><None></None></field>
+        <field name="favorite_toy" type="PolymorphicEmbeddedModelField"><None></None></field>
+        <field name="toys" type="PolymorphicEmbeddedModelArrayField"><None></None></field>
+      </object></field>
+  </object>
+  <object model="serializers_.person" pk="000000000000000000000002">
+    <field name="name" type="CharField">Marla</field>
+    <field name="pet" type="PolymorphicEmbeddedModelField">
+      <object model="serializers_.cat">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="name" type="CharField">April</field>
+        <field name="purs" type="BooleanField">True</field>
+        <field name="weight" type="DecimalField"><None></None></field>
+        <field name="favorite_toy" type="PolymorphicEmbeddedModelField"><None></None></field>
+        <field name="toys" type="PolymorphicEmbeddedModelArrayField"><None></None></field>
+      </object></field>
+  </object>
+</django-objects>""",
+        "polymorphic_embedded_model_field_null": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.person">
+    <field name="name" type="CharField"></field>
+    <field name="pet" type="PolymorphicEmbeddedModelField"><None></None></field>
+  </object>
+</django-objects>""",
+        "polymorphic_embedded_model_array_field": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.owner" pk="000000000000000000000001">
+    <field name="name" type="CharField">Cliff</field>
+    <field name="pets" type="PolymorphicEmbeddedModelArrayField">
+      <object model="serializers_.dog">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="name" type="CharField">Woofer</field>
+        <field name="barks" type="BooleanField">True</field>
+        <field name="created_at" type="DateTimeField"><None></None></field>
+        <field name="updated_at" type="DateTimeField"><None></None></field>
+        <field name="favorite_toy" type="PolymorphicEmbeddedModelField"><None></None></field>
+        <field name="toys" type="PolymorphicEmbeddedModelArrayField"><None></None></field>
+      </object>
+      <object model="serializers_.dog">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="name" type="CharField">Joey</field>
+        <field name="barks" type="BooleanField">True</field>
+        <field name="created_at" type="DateTimeField"><None></None></field>
+        <field name="updated_at" type="DateTimeField"><None></None></field>
+        <field name="favorite_toy" type="PolymorphicEmbeddedModelField"><None></None></field>
+        <field name="toys" type="PolymorphicEmbeddedModelArrayField"><None></None></field>
+      </object></field>
+  </object>
+  <object model="serializers_.owner" pk="000000000000000000000002">
+    <field name="name" type="CharField">Marla</field>
+    <field name="pets" type="PolymorphicEmbeddedModelArrayField">
+      <object model="serializers_.cat">
+        <field name="id" type="ObjectIdAutoField"><None></None></field>
+        <field name="name" type="CharField">April</field>
+        <field name="purs" type="BooleanField">True</field>
+        <field name="weight" type="DecimalField"><None></None></field>
+        <field name="favorite_toy" type="PolymorphicEmbeddedModelField"><None></None></field>
+        <field name="toys" type="PolymorphicEmbeddedModelArrayField"><None></None></field>
+      </object></field>
+  </object>
+</django-objects>""",
+        "polymorphic_embedded_model_array_field_null": """<?xml version="1.0" encoding="utf-8"?>
+<django-objects version="1.0">
+  <object model="serializers_.owner">
+    <field name="name" type="CharField"></field>
+    <field name="pets" type="PolymorphicEmbeddedModelArrayField"><None></None></field>
+  </object>
+</django-objects>""",
+    }
+
+
+class YAMLSerializerTests(SerializationTests, TestCase):
+    serialization_format = "yaml"
+    expected_data = {
+        "embedded_model_field": """- model: serializers_.book
+  pk: '000000000000000000000001'
+  fields:
+    name: Hamlet
+    author:
+      id: null
+      name: Shakespeare
+      age: 55
+      address:
+        id: null
+        city: NYC
+        state: NY
+        zip_code: null
+""",
+        "embedded_model_field_null": """- model: serializers_.book
+  pk: null
+  fields:
+    name: ''
+    author: null
+""",
+        "embedded_model_array_field": """- model: serializers_.movie
+  pk: '000000000000000000000001'
+  fields:
+    title: Lion King
+    reviews:
+    - id: null
+      title: The best
+      rating: 10
+    - id: null
+      title: Mediocre
+      rating: 5
+    - id: null
+      title: Horrible
+      rating: 1
+""",
+        "embedded_model_array_field_null": """- model: serializers_.movie
+  pk: null
+  fields:
+    title: ''
+    reviews: null
+""",
+        "polymorphic_embedded_model_field": """- model: serializers_.person
+  pk: '000000000000000000000001'
+  fields:
+    name: Cliff
+    pet:
+      id: null
+      name: Woofer
+      barks: true
+      created_at: null
+      updated_at: null
+      favorite_toy: null
+      toys: null
+      _label: serializers_.Dog
+- model: serializers_.person
+  pk: '000000000000000000000002'
+  fields:
+    name: Marla
+    pet:
+      id: null
+      name: April
+      purs: true
+      weight: null
+      favorite_toy: null
+      toys: null
+      _label: serializers_.Cat
+""",
+        "polymorphic_embedded_model_field_null": """- model: serializers_.person
+  pk: null
+  fields:
+    name: ''
+    pet: null
+""",
+        "polymorphic_embedded_model_array_field": """- model: serializers_.owner
+  pk: '000000000000000000000001'
+  fields:
+    name: Cliff
+    pets:
+    - id: null
+      name: Woofer
+      barks: true
+      created_at: null
+      updated_at: null
+      favorite_toy: null
+      toys: null
+      _label: serializers_.Dog
+    - id: null
+      name: Joey
+      barks: true
+      created_at: null
+      updated_at: null
+      favorite_toy: null
+      toys: null
+      _label: serializers_.Dog
+- model: serializers_.owner
+  pk: '000000000000000000000002'
+  fields:
+    name: Marla
+    pets:
+    - id: null
+      name: April
+      purs: true
+      weight: null
+      favorite_toy: null
+      toys: null
+      _label: serializers_.Cat
+""",
+        "polymorphic_embedded_model_array_field_null": """- model: serializers_.owner
+  pk: null
+  fields:
+    name: ''
+    pets: null
+""",
+    }


### PR DESCRIPTION
These changes work with the model field serializer API proposed for Django 6.2: https://github.com/django/django/pull/21233

fixes #243 