### PR TITLE
INTPYTHON-950 Re-raise DatabaseError from atomic() when commit fails (opt-in)

### DIFF
--- a/django_mongodb_backend/transaction.py
+++ b/django_mongodb_backend/transaction.py
@@ -16,8 +16,9 @@ class Atomic(ContextDecorator):
     Simplified from django.db.transaction.
     """
 
-    def __init__(self, using):
+    def __init__(self, using, raise_on_commit_failure):
         self.using = using
+        self.raise_on_commit_failure = raise_on_commit_failure
 
     def __enter__(self):
         connection = get_connection(self.using)
@@ -45,6 +46,8 @@ class Atomic(ContextDecorator):
                     connection.commit_mongo()
                 except DatabaseError:
                     connection.rollback_mongo()
+                    if self.raise_on_commit_failure:
+                        raise
         else:
             # atomic() exited with an error.
             if not connection.in_atomic_block_mongo:
@@ -52,10 +55,10 @@ class Atomic(ContextDecorator):
                 connection.rollback_mongo()
 
 
-def atomic(using=None):
+def atomic(using=None, raise_on_commit_failure=False):
     # Bare decorator: @atomic -- although the first argument is called `using`,
     # it's actually the function being decorated.
     if callable(using):
-        return Atomic(DEFAULT_DB_ALIAS)(using)
+        return Atomic(DEFAULT_DB_ALIAS, raise_on_commit_failure=raise_on_commit_failure)(using)
     # Decorator: @atomic(...) or context manager: with atomic(...): ...
-    return Atomic(using)
+    return Atomic(using, raise_on_commit_failure=raise_on_commit_failure)

--- a/tests/transactions_/tests.py
+++ b/tests/transactions_/tests.py
@@ -1,3 +1,5 @@
+from unittest.mock import patch
+
 from django.db import DatabaseError, connection
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
 
@@ -146,6 +148,63 @@ class AtomicTests(TransactionTestCase):
         with transaction.atomic():
             pass
 
+    def test_raise_on_commit_failure_if_flag_true_context_manager(self):
+        with (
+            patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed")),
+            self.assertRaisesMessage(DatabaseError, "commit failed"),
+            transaction.atomic(raise_on_commit_failure=True),
+        ):
+            Reporter.objects.create(first_name="Tintin")
+        self.assertSequenceEqual(Reporter.objects.all(), [])
+
+    def test_raise_on_commit_failure_if_flag_true_decorator(self):
+        @transaction.atomic(raise_on_commit_failure=True)
+        def make_reporter():
+            Reporter.objects.create(first_name="Tintin")
+
+        with (
+            patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed")),
+            self.assertRaisesMessage(DatabaseError, "commit failed"),
+        ):
+            make_reporter()
+
+        self.assertSequenceEqual(Reporter.objects.all(), [])
+
+    def test_dont_raise_on_commit_failure_if_flag_false_context_manager(self):
+        with (
+            patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed")),
+            transaction.atomic(raise_on_commit_failure=False),
+        ):
+            Reporter.objects.create(first_name="Tintin")
+        self.assertSequenceEqual(Reporter.objects.all(), [])
+
+    def test_dont_raise_on_commit_failure_if_flag_false_decorator(self):
+        @transaction.atomic(raise_on_commit_failure=False)
+        def make_reporter():
+            Reporter.objects.create(first_name="Tintin")
+
+        with (patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed"))):
+            make_reporter()
+
+        self.assertSequenceEqual(Reporter.objects.all(), [])
+
+    def test_dont_raise_on_commit_failure_if_flag_not_set_context_manager(self):
+        with (
+            patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed")),
+            transaction.atomic(),
+        ):
+            Reporter.objects.create(first_name="Tintin")
+        self.assertSequenceEqual(Reporter.objects.all(), [])
+
+    def test_dont_raise_on_commit_failure_if_flag_not_set_decorator(self):
+        @transaction.atomic
+        def make_reporter():
+            Reporter.objects.create(first_name="Tintin")
+
+        with (patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed"))):
+            make_reporter()
+
+        self.assertSequenceEqual(Reporter.objects.all(), [])
 
 @skipIfDBFeature("_supports_transactions")
 class AtomicNotSupportedTests(TransactionTestCase):

--- a/tests/transactions_/tests.py
+++ b/tests/transactions_/tests.py
@@ -183,7 +183,7 @@ class AtomicTests(TransactionTestCase):
         def make_reporter():
             Reporter.objects.create(first_name="Tintin")
 
-        with (patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed"))):
+        with patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed")):
             make_reporter()
 
         self.assertSequenceEqual(Reporter.objects.all(), [])
@@ -201,10 +201,11 @@ class AtomicTests(TransactionTestCase):
         def make_reporter():
             Reporter.objects.create(first_name="Tintin")
 
-        with (patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed"))):
+        with patch.object(connection, "commit_mongo", side_effect=DatabaseError("commit failed")):
             make_reporter()
 
         self.assertSequenceEqual(Reporter.objects.all(), [])
+
 
 @skipIfDBFeature("_supports_transactions")
 class AtomicNotSupportedTests(TransactionTestCase):


### PR DESCRIPTION
<!-- Thanks for contributing! -->
<!-- Please ensure that the title of the PR is in the following form:
[JIRA TICKET] Issue Title

If you are an external contributor and there is no JIRA ticket associated with your change, then use your best judgement
for the PR title. A MongoDB employee will create a JIRA ticket and edit the name and links as appropriate.

Note on AI Contributions:
We only accept pull requests that are authored and submitted by human contributors who fully understand the changes they are proposing.
All contributions must be written and understood by human contributors. Please read about our policy in our contributing guide.
-->
Re-raise DatabaseError from atomic() when commit fails (opt-in)

## Changes in this PR

<!-- What changes did you make to the code? What new APIs (public or private) were added, removed, or edited to generate the desired outcome explained in the above summary? -->

Atomic transactions are used in our production project everywhere. Sometimes there is a situation when MongoDB returns an error when committing a transaction. In this case, the transaction is quietly rolled back. I believe that this behavior is incorrect, and such errors should be thrown further, so that the developer can handle such an exception on their own. Currently, in our project, we have patched `Atomic.__exit__`, but in the future, we would like to get rid of this hack.

What is done:
- Added `raise_on_commit_failure` flag with default value `False` to `atomic` context manager and decorator
- Added logic: 
- - if `raise_on_commit_failure` is set to False, then the behavior remains the same as it was before. This allows you to maintain compatibility with previous versions and allows developers to safely implement a new version of the library.
- - if `raise_on_commit_failure` is set to True, then if MongoDB returns `DatabaseError` on commit transaction, transaction rollbacks and the exception throws further

## Test Plan

<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why. All code should be tested in some way – so please list what your validation strategy was. -->

Added unit tests with test cases:
1. Using context manager, MongoDB raises `DatabaseError`, `raise_on_commit_failure` is set to True, exception was raised and new record in collection didn't appear
2. Using decorator, MongoDB raises `DatabaseError`, `raise_on_commit_failure` is set to True, exception was raised and new record in collection didn't appear
3. Using context manager, MongoDB raises `DatabaseError`, `raise_on_commit_failure` is set to False, exception was not raised and new record in collection didn't appear
4. Using decorator, MongoDB raises `DatabaseError`, `raise_on_commit_failure` is set to False, exception was not raised and new record in collection didn't appear
5. Using context manager, MongoDB raises `DatabaseError`, `raise_on_commit_failure` isn't set, exception was not raised and new record in collection didn't appear
4. Using decorator, MongoDB raises `DatabaseError`, `raise_on_commit_failure` isn't set, exception was not raised and new record in collection didn't appear

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [x] Did you update the changelog (if necessary)? - I didn't find it
- [x] Is the intention of the code captured in relevant tests?
- [x] If there are new TODOs, has a related JIRA ticket been created?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?
