### PR TITLE
INTPYTHON-950 Prevent transaction.atomic() from swallowing commit exceptions

### DIFF
--- a/django_mongodb_backend/transaction.py
+++ b/django_mongodb_backend/transaction.py
@@ -45,6 +45,7 @@ class Atomic(ContextDecorator):
                     connection.commit_mongo()
                 except DatabaseError:
                     connection.rollback_mongo()
+                    raise
         else:
             # atomic() exited with an error.
             if not connection.in_atomic_block_mongo:

--- a/docs/releases/5.2.x.rst
+++ b/docs/releases/5.2.x.rst
@@ -15,7 +15,8 @@ New features
 Bug fixes
 ---------
 
-- ...
+- Prevented :func:`~django_mongodb_backend.transaction.atomic` from silencing
+  exceptions raised on commit.
 
 Performance improvements
 ------------------------

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -17,6 +17,9 @@ Bug fixes
 
 - Made creating models with expressions raise a helpful error message.
 
+- Prevented :func:`~django_mongodb_backend.transaction.atomic` from silencing
+  exceptions raised on commit.
+
 6.0.3
 =====
 

--- a/tests/transactions_/tests.py
+++ b/tests/transactions_/tests.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 from django.db import DatabaseError, connection
 from django.test import TransactionTestCase, skipIfDBFeature, skipUnlessDBFeature
 
@@ -145,6 +147,17 @@ class AtomicTests(TransactionTestCase):
         connection.close_pool()
         with transaction.atomic():
             pass
+
+    def test_failure_on_commit_transaction(self):
+        """transaction.atomic() re-raises an error during transaction commit."""
+        msg = "commit failed"
+        with (
+            mock.patch.object(connection, "commit_mongo", side_effect=DatabaseError(msg)),
+            self.assertRaisesMessage(DatabaseError, msg),
+            transaction.atomic(),
+        ):
+            Reporter.objects.create(first_name="Tintin")
+        self.assertSequenceEqual(Reporter.objects.all(), [])
 
 
 @skipIfDBFeature("_supports_transactions")


### PR DESCRIPTION
Simplified from https://github.com/mongodb/django-mongodb-backend/pull/524

The behavior is [consistent with Django's transaction.atomic()](https://github.com/django/django/blob/d24160ab4855f6971aa1f437720adca6330048a2/django/db/transaction.py#L261-L271).