### PR TITLE
Update broken Vector Search links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,6 +50,7 @@ intersphinx_mapping = {
     "pymongo-api": ("https://pymongo.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3/", None),
     "atlas": ("https://www.mongodb.com/docs/atlas/", None),
+    "vector-search": ("https://www.mongodb.com/docs/vector-search/", None),
     "manual": ("https://www.mongodb.com/docs/manual/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master", None),
 }

--- a/docs/ref/models/indexes.rst
+++ b/docs/ref/models/indexes.rst
@@ -88,7 +88,7 @@ minutes, depending on the size of the collection.
 .. class:: VectorSearchIndex(*, fields=(), name=None, similarities)
 
     A subclass of :class:`SearchIndex` that creates a :doc:`vector search index
-    <atlas:atlas-vector-search/vector-search-type>` on the given field(s).
+    <vector-search:index/vector-search-type>` on the given field(s).
 
     The index must reference at least one vector field: an :class:`.ArrayField`
     with a :attr:`~.ArrayField.base_field` of
@@ -101,7 +101,7 @@ minutes, depending on the size of the collection.
 
     Available values for the required ``similarities`` keyword argument are
     ``"cosine"``, ``"dotProduct"``, and ``"euclidean"`` (see
-    :ref:`atlas:avs-similarity-functions` for how to choose). You can provide
-    this value either a string, in which case that value will be applied to all
-    vector fields, or a list or tuple of values with a similarity corresponding
-    to each vector field.
+    :ref:`vector-search:avs-similarity-functions` for how to choose). You can
+    provide this value either a string, in which case that value will be
+    applied to all vector fields, or a list or tuple of values with a
+    similarity corresponding to each vector field.

--- a/docs/ref/models/search.rst
+++ b/docs/ref/models/search.rst
@@ -473,7 +473,7 @@ This allows for more expressive and readable search logic:
 .. class:: SearchVector(path, query_vector, limit, *, num_candidates=None, exact=None, filter=None)
 
 Performs vector similarity search using the :doc:`$vectorSearch stage
-<atlas:atlas-vector-search/vector-search-stage>`.
+<vector-search:query/aggregation-stages/vector-search-stage>`.
 
 Retrieves documents whose vector field is most similar to a given query vector,
 using either approximate or exact nearest neighbor search.


### PR DESCRIPTION
Docs were restructured in https://github.com/10gen/docs-mongodb-internal/commit/52ada8fb82ee2aa8688776df8a92834adc03727d.