### PR TITLE
INTPYTHON-955 Add debug logging of QuerySet.explain() queries

### DIFF
--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -890,7 +890,7 @@ class SQLCompiler(compiler.SQLCompiler):
         for option in self.connection.ops.explain_options:
             if value := options.get(option):
                 kwargs[option] = value
-        explain = self.connection.database.command(
+        explain = self.connection.get_database().command(
             "explain",
             {"aggregate": self.collection_name, "pipeline": pipeline, "cursor": {}},
             **kwargs,

--- a/django_mongodb_backend/operations.py
+++ b/django_mongodb_backend/operations.py
@@ -37,6 +37,7 @@ class DatabaseOperations(GISOperations, BaseDatabaseOperations):
         Combinable.BITXOR: "bitXor",
     }
     explain_options = {"comment", "verbosity"}
+    explain_prefix = "db.command('explain',"  # Expected value for tests.
 
     def adapt_datefield_value(self, value):
         """Store DateField as datetime."""

--- a/django_mongodb_backend/utils.py
+++ b/django_mongodb_backend/utils.py
@@ -67,6 +67,7 @@ class OperationDebugWrapper:
     # The PyMongo database and collection methods that this backend uses.
     wrapped_methods = {
         "aggregate",
+        "command",
         "create_collection",
         "create_indexes",
         "create_search_index",

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -20,6 +20,8 @@ Bug fixes
 - Prevented :func:`~django_mongodb_backend.transaction.atomic` from silencing
   exceptions raised on commit.
 
+- Added debug logging of ``QuerySet.explain()`` queries.
+
 6.0.3
 =====
 


### PR DESCRIPTION
Tested by reverting this commit in the Django fork:
```diff
commit 9992b908e47ad11f5d129e49995b7ca920d11801
Author: Tim Graham <timograham@gmail.com>
Date:   Fri Aug 16 18:02:38 2024 -0400

    drop requirement that QuerySet.explain() log a query

diff --git a/tests/queries/test_explain.py b/tests/queries/test_explain.py
index 95ca913cfc..40049caead 100644
--- a/tests/queries/test_explain.py
+++ b/tests/queries/test_explain.py
@@ -35,31 +35,30 @@ class ExplainTests(TestCase):
         for idx, queryset in enumerate(querysets):
             for format in all_formats:
                 with self.subTest(format=format, queryset=idx):
-                    with self.assertNumQueries(1) as captured_queries:
-                        result = queryset.explain(format=format)
-                        self.assertTrue(
-                            captured_queries[0]["sql"].startswith(
-                                connection.ops.explain_prefix
+                    result = queryset.explain(format=format)
+                    # self.assertTrue(
+                    #     captured_queries[0]["sql"].startswith(
+                    #         connection.ops.explain_prefix
+                    #     )
+                    # )
+                    self.assertIsInstance(result, str)
+                    self.assertTrue(result)
+                    if not format:
+                        continue
+                    if format.lower() == "xml":
+                        try:
+                            xml.etree.ElementTree.fromstring(result)
+                        except xml.etree.ElementTree.ParseError as e:
+                            self.fail(
+                                f"QuerySet.explain() result is not valid XML: {e}"
+                            )
+                    elif format.lower() == "json":
+                        try:
+                            json.loads(result)
+                        except json.JSONDecodeError as e:
+                            self.fail(
+                                f"QuerySet.explain() result is not valid JSON: {e}"
                             )
-                        )
-                        self.assertIsInstance(result, str)
-                        self.assertTrue(result)
-                        if not format:
-                            continue
-                        if format.lower() == "xml":
-                            try:
-                                xml.etree.ElementTree.fromstring(result)
-                            except xml.etree.ElementTree.ParseError as e:
-                                self.fail(
-                                    f"QuerySet.explain() result is not valid XML: {e}"
-                                )
-                        elif format.lower() == "json":
-                            try:
-                                json.loads(result)
-                            except json.JSONDecodeError as e:
-                                self.fail(
-                                    f"QuerySet.explain() result is not valid JSON: {e}"
-                                )
 
     def test_unknown_options(self):
         with self.assertRaisesMessage(ValueError, "Unknown options: TEST, TEST2"):
```