### PR TITLE
INTPYTHON-530: Run performance tests on a regular cadence

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -247,6 +247,6 @@ buildvariants:
     display_name: Performance Tests
     run_on:
       - rhel90-dbx-perf-large
-    cron: '0 16 * * MON'  # Daily
+    cron: '0 16 * * *'  # Run daily at 16:00 UTC
     tasks:
       - name: run-performance-tests

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -247,6 +247,6 @@ buildvariants:
     display_name: Performance Tests
     run_on:
       - rhel90-dbx-perf-large
-    batchtime: 1440  # Daily
+    cron: '0 16 * * MON'  # Daily
     tasks:
       - name: run-performance-tests


### PR DESCRIPTION
[INTPYTHON-530](https://jira.mongodb.org/browse/INTPYTHON-530)

## Changes in this PR

Modification to the Evergreen config to support regular performance testing. Prior to this change, the performance tests were only run commits a maximum of once every 24 hours. After this change, performance tests should be run daily with or without any new commits.

## Test Plan

Check on Evergreen that the performance tests are running at a daily cadence instead of once a day only with commits.

## Checklist

### Checklist for Author

- [n/a] Did you update the changelog (if necessary)?
- [n/a] Is the intention of the code captured in relevant tests?
- [n/a] If there are new TODOs, has a related JIRA ticket been created?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?