### PR TITLE
INTPYTHON-530 Temporarily degrade performance test to verify Splunk alerting

### DIFF
--- a/performance_tests/perf/test_small_flat_doc.py
+++ b/performance_tests/perf/test_small_flat_doc.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import time
+from pathlib import Path
 from unittest import TestCase
 
 from bson import encode, json_util

--- a/performance_tests/perf/test_small_flat_doc.py
+++ b/performance_tests/perf/test_small_flat_doc.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from time import time
+import time
 from unittest import TestCase
 
 from bson import encode, json_util

--- a/performance_tests/perf/test_small_flat_doc.py
+++ b/performance_tests/perf/test_small_flat_doc.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+from time import time
 from unittest import TestCase
 
 from bson import encode, json_util
@@ -59,6 +60,7 @@ class TestSmallFlatDocUpdate(SmallFlatDocTest, TestCase):
         for model in self.models:
             model.field1 = "updated_value" + str(self.iteration)
             model.save()
+            time.sleep(0.001)
         self.iteration += 1
 
 


### PR DESCRIPTION
[INTPYTHON-530](https://jira.mongodb.org/browse/INTPYTHON-530)

## Changes in this PR

Introducing a degradation on a performance test to verify alerting was properly set up on Splunk. Unfortunately (or fortunately), performance is only surfaced to Splunk on mainline commits. Performance tests are run on Evergreen a maximum of every 24 hours. I will revert this PR after the next alert check occurs (every hour).

## Test Plan

<!-- How did you test the code? If you added unit tests, you can say that. If you didn’t introduce unit tests, explain why. All code should be tested in some way – so please list what your validation strategy was. -->

## Checklist

<!-- Do not delete the items provided on this checklist -->

### Checklist for Author

- [ ] Did you update the changelog (if necessary)?
- [ ] Is the intention of the code captured in relevant tests?
- [ ] If there are new TODOs, has a related JIRA ticket been created?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?
