### PR TITLE
Disable performance tests on pull requests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -173,6 +173,7 @@ tasks:
       - func: "teardown csfle"
 
   - name: run-performance-tests
+    patchable: false
     commands:
       - func: "run performance tests"
       - func: "attach performance test results"


### PR DESCRIPTION
This approach isn't ideal because it won't allow the tests to be triggered on a PR manually (for example, when new benchmarks are added). Instead, we might follow the "pr" tag approach that the mongodb-python-driver Evergreen config uses.

However, I think we should revisit this later if that solution seems justified. Temporarily reverting this patch in a PR branch may work to check the performance tests there if need be. Evergreen shows we waste $0.30 each time this job runs on a PR since the results aren't used. For comparison, running the non-performance tests costs about $0.20 total.