### PR TITLE
Bump CI from MongoDB 8.2 to 8.3

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -224,20 +224,20 @@ buildvariants:
       - name: run-tests
 
   - name: tests-8-qe-local
-    display_name: Run Tests 8.2 QE local KMS
+    display_name: Run Tests 8.3 QE local KMS
     run_on: rhel87-small
     expansions:
-      MONGODB_VERSION: "8.2"
+      MONGODB_VERSION: "8.3"
       TOPOLOGY: replica_set
       DJANGO_SETTINGS_MODULE: "encrypted_settings"
     tasks:
       - name: run-encryption-tests
 
   - name: tests-8-qe-aws
-    display_name: Run Tests 8.2 QE AWS KMS
+    display_name: Run Tests 8.3 QE AWS KMS
     run_on: rhel87-small
     expansions:
-      MONGODB_VERSION: "8.2"
+      MONGODB_VERSION: "8.3"
       TOPOLOGY: replica_set
       DJANGO_SETTINGS_MODULE: "encrypted_aws_settings"
     tasks:

--- a/.github/workflows/test-python-encryption.yml
+++ b/.github/workflows/test-python-encryption.yml
@@ -54,8 +54,8 @@ jobs:
         run: bash .github/workflows/start_local_atlas.sh mongodb/mongodb-atlas-local:8.0
       - name: Download mongo_crypt_shared
         run: |
-          wget https://downloads.mongodb.com/linux/mongo_crypt_shared_v1-linux-x86_64-enterprise-ubuntu2404-8.2.3.tgz
-          tar -xvzf mongo_crypt_shared_v1-linux-x86_64-enterprise-ubuntu2404-8.2.3.tgz lib/mongo_crypt_v1.so
+          wget https://downloads.mongodb.com/linux/mongo_crypt_shared_v1-linux-x86_64-enterprise-ubuntu2404-8.3.2.tgz
+          tar -xvzf mongo_crypt_shared_v1-linux-x86_64-enterprise-ubuntu2404-8.3.2.tgz lib/mongo_crypt_v1.so
       - name: Run tests
         run: python3 django_repo/tests/runtests_.py
     permissions:


### PR DESCRIPTION
MongoDB 8.2 is EOL July 31, 2026.