### PR TITLE
INTPYTHON-986 Add sphinx linkcheck to CI

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -50,3 +50,25 @@ jobs:
           make html
     permissions:
         contents: read
+  linkcheck:
+    name: Docs Link Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6.0.2
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v6
+        with:
+          cache: 'pip'
+          cache-dependency-path: 'pyproject.toml'
+          python-version: '3.12'
+      - name: Install dependencies
+        run: |
+          pip install -U pip
+          pip install -e ".[docs]"
+      - name: Check links
+        run: |
+          cd docs
+          make linkcheck
+    permissions:
+        contents: read


### PR DESCRIPTION
[INTPYTHON-986](https://jira.mongodb.org/browse/INTPYTHON-986)

## Changes in this PR

Adds a `linkcheck` job to the linters CI workflow that runs `sphinx-build -M linkcheck` against the docs. The job runs in parallel with the existing `Docs Checks` job. URLs that break due to JavaScript-rendered anchors are already excluded via `linkcheck_ignore` in `docs/conf.py`.

## Test Plan

CI will validate the link checker runs and passes.

## Checklist

### Checklist for Author

- [ ] Did you update the changelog (if necessary)?
- [x] Is the intention of the code captured in relevant tests?
- [ ] If there are new TODOs, has a related JIRA ticket been created?

### Checklist for Reviewer

- [ ] Does the title of the PR reference a JIRA Ticket?
- [ ] Do you fully understand the implementation? (Would you be comfortable explaining how this code works to someone else?)
- [ ] Have you checked for spelling & grammar errors?
- [ ] Is all relevant documentation (README or docstring) updated?