### PR TITLE
INTPYTHON-734 Add support for pattern lookups on non-string fields

### DIFF
--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -64,17 +64,8 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
         # BaseExpression.convert_value() crashes with Decimal128.
         "aggregation.tests.AggregateTestCase.test_combine_different_types",
         "annotations.tests.NonAggregateAnnotationTestCase.test_combined_f_expression_annotation_with_aggregation",
-        # Pattern lookups that use regexMatch don't work on JSONField:
-        # Unsupported conversion from array to string in $convert
-        "model_fields.test_jsonfield.TestQuerying.test_icontains",
         # Unexpected alias_refcount in alias_map.
         "queries.tests.Queries1Tests.test_order_by_tables",
-        # Pattern lookups (startswith, regex, etc.) don't work on non-string
-        # fields: https://jira.mongodb.org/browse/INTPYTHON-734
-        "admin_changelist.tests.ChangeListTests.test_pk_in_search_fields",
-        "admin_changelist.tests.ChangeListTests.test_related_field_multiple_search_terms",
-        "lookup.tests.LookupTests.test_lookup_int_as_str",
-        "lookup.tests.LookupTests.test_regex_non_string",
         # The $sum aggregation returns 0 instead of None for null.
         "aggregation.test_filter_argument.FilteredAggregateTests.test_plain_annotate",
         "aggregation.tests.AggregateTestCase.test_aggregation_default_passed_another_aggregate",
@@ -116,6 +107,13 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
     def django_test_expected_failures(self):
         expected_failures = super().django_test_expected_failures
         expected_failures.update(self._django_test_expected_failures)
+        if not self.is_mongodb_8_3:
+            expected_failures.update(
+                {
+                    # $convert supports array to string in MongoDB 8.3+.
+                    "model_fields.test_jsonfield.TestQuerying.test_icontains",
+                }
+            )
         return expected_failures
 
     _django_test_skips = {

--- a/django_mongodb_backend/lookups.py
+++ b/django_mongodb_backend/lookups.py
@@ -2,11 +2,13 @@ from django.db.models.fields.related_lookups import In, RelatedIn
 from django.db.models.lookups import (
     BuiltinLookup,
     FieldGetDbPrepValueIterableMixin,
+    IExact,
     IsNull,
     LessThan,
     LessThanOrEqual,
     Lookup,
     PatternLookup,
+    Regex,
     UUIDTextMixin,
 )
 
@@ -144,8 +146,14 @@ def _strip_percent_signs(lookup_name, value):
 
 def pattern_lookup_expr(self, compiler, connection):
     lhs_mql = process_lhs(self, compiler, connection, as_expr=True)
+    # Cast the LHS to string if needed.
+    if self.lhs.output_field.db_type(connection) != "string":
+        lhs_mql = {"$toString": lhs_mql}
     value = process_rhs(self, compiler, connection, as_expr=True)
     if hasattr(self.rhs, "as_mql"):
+        # Cast RHS to string if needed.
+        if self.rhs.output_field.db_type(connection) != "string":
+            value = {"$toString": value}
         # If value is a column reference, escape $regexMatch special chars.
         # Analogous to PatternLookup.get_rhs_op() / pattern_esc.
         for find, replacement in REGEX_MATCH_ESCAPE_CHARS:
@@ -157,10 +165,57 @@ def pattern_lookup_expr(self, compiler, connection):
     return connection.mongo_expr_operators[self.lookup_name](lhs_mql, value)
 
 
+def _supports_regex_path(output_field, connection):
+    """
+    Return whether the $regex query operator can match `output_field` directly.
+
+    It applies to string fields and, thanks to MongoDB's implicit array
+    traversal, to arrays of strings as well.
+    """
+    if output_field.db_type(connection) == "string":
+        return True
+    base_field = getattr(output_field, "base_field", None)
+    return base_field is not None and base_field.db_type(connection) == "string"
+
+
 def pattern_lookup_path(self, compiler, connection):
+    # $regex can't operate on a non-string field; fall back to $expr with
+    # $toString.
+    if not _supports_regex_path(self.lhs.output_field, connection):
+        return {"$expr": pattern_lookup_expr(self, compiler, connection)}
     lhs_mql = process_lhs(self, compiler, connection)
     value = process_rhs(self, compiler, connection)
     value = _strip_percent_signs(self.lookup_name, value)
+    return connection.mongo_operators[self.lookup_name](lhs_mql, value)
+
+
+def regex_expr(self, compiler, connection):
+    """
+    Used by iexact, regex, and iregex. Pattern lookups, handled by
+    pattern_lookup_expr(), have similar logic to cast LHS/RHS as needed.
+    """
+    lhs_mql = process_lhs(self, compiler, connection, as_expr=True)
+    # Cast the LHS to string if needed.
+    if self.lhs.output_field.db_type(connection) != "string":
+        lhs_mql = {"$toString": lhs_mql}
+    value = process_rhs(self, compiler, connection, as_expr=True)
+    # Cast the RHS to string if needed.
+    if hasattr(self.rhs, "as_mql") and self.rhs.output_field.db_type(connection) != "string":
+        value = {"$toString": value}
+    return connection.mongo_expr_operators[self.lookup_name](lhs_mql, value)
+
+
+def regex_path(self, compiler, connection):
+    """
+    Used by iexact, regex, and iregex. Pattern lookups, handled by
+    pattern_lookup_path(), have similar logic to cast LHS/RHS as needed.
+    """
+    # $regex can't operate on a non-string field; fall back to $expr with
+    # $toString.
+    if not _supports_regex_path(self.lhs.output_field, connection):
+        return {"$expr": regex_expr(self, compiler, connection)}
+    lhs_mql = process_lhs(self, compiler, connection)
+    value = process_rhs(self, compiler, connection)
     return connection.mongo_operators[self.lookup_name](lhs_mql, value)
 
 
@@ -185,6 +240,8 @@ def register_lookups():
     FieldGetDbPrepValueIterableMixin.resolve_expression_parameter = (
         field_resolve_expression_parameter
     )
+    IExact.as_mql_expr = regex_expr
+    IExact.as_mql_path = regex_path
     In.as_mql_expr = RelatedIn.as_mql_expr = wrap_in(builtin_lookup_expr)
     In.as_mql_path = RelatedIn.as_mql_path = wrap_in(builtin_lookup_path)
     In.get_subquery_wrapping_pipeline = get_subquery_wrapping_pipeline
@@ -195,5 +252,7 @@ def register_lookups():
     Lookup.can_use_path = lookup_can_use_path
     PatternLookup.as_mql_expr = pattern_lookup_expr
     PatternLookup.as_mql_path = pattern_lookup_path
+    Regex.as_mql_expr = regex_expr
+    Regex.as_mql_path = regex_path
     UUIDTextMixin.as_mql_expr = uuid_text_mixin_as_mql_expr
     UUIDTextMixin.as_mql_path = uuid_text_mixin_as_mql_path

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -50,6 +50,11 @@ Bug fixes
   :class:`~django_mongodb_backend.fields.PolymorphicEmbeddedModelArrayField`
   that specifies ``embedded_models`` as a list of concrete models.
 
+- Fixed queries for pattern matching lookups (:lookup:`iexact`,
+  :lookup:`startswith`, :lookup:`istartswith`, :lookup:`endswith`,
+  :lookup:`iendswith`, :lookup:`contains`, :lookup:`icontains`,
+  :lookup:`regex`, and :lookup:`iregex`) on non-string fields.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/docs/topics/known-issues.rst
+++ b/docs/topics/known-issues.rst
@@ -65,11 +65,6 @@ Querying
   - You can study the skipped tests in ``DatabaseFeatures.django_test_skips``
     for more details on known issues.
 
-- Pattern matching lookups (:lookup:`iexact`, :lookup:`startswith`,
-  :lookup:`istartswith`, :lookup:`endswith`, :lookup:`iendswith`,
-  :lookup:`contains`, :lookup:`icontains`, :lookup:`regex`,
-  and :lookup:`iregex`) don't support non-string fields.
-
 Database functions
 ==================
 


### PR DESCRIPTION
I've added tests in Django's test suite to cover all cases: https://github.com/django/django/pull/21468.