### PR TITLE
INTPYTHON-643 Prevent repeated errors on nested embedded forms

### DIFF
--- a/django_mongodb_backend/forms/fields/embedded_model.py
+++ b/django_mongodb_backend/forms/fields/embedded_model.py
@@ -1,81 +1,114 @@
+from itertools import chain
+
 from django import forms
+from django.core.exceptions import ValidationError
 from django.forms.models import modelform_factory
 from django.utils.safestring import mark_safe
-from django.utils.translation import gettext_lazy as _
 
 
-class EmbeddedModelField(forms.MultiValueField):
-    default_error_messages = {
-        "invalid": _("Enter a list of values."),
-        "incomplete": _("Enter all required values."),
-    }
+class EmbeddedModelField(forms.Field):
+    """
+    Form field for an embedded model, backed by a ModelForm.
+
+    A single nested form instance (built in EmbeddedModelBoundField) is the
+    source of truth for both validation and rendering, so each validation error
+    renders inline next to the subfield that produced it instead of being
+    aggregated onto this parent field. The nested form's messages are still
+    aggregated into the parent form's errors dict (so form.errors[name] stays
+    meaningful), but EmbeddedModelBoundField.errors suppresses them at render
+    time to avoid showing them twice.
+    """
 
     def __init__(self, model, prefix, *args, **kwargs):
-        form_kwargs = {}
-        # To avoid collisions with other fields on the form, each subfield must
-        # be prefixed with the name of the field.
-        form_kwargs["prefix"] = prefix
-        self.form_kwargs = form_kwargs
+        self.model = model
+        # To avoid collisions with other fields on the form, each subfield is
+        # prefixed with the name of this field.
+        self.prefix = prefix
         self.model_form_cls = modelform_factory(model, fields="__all__")
-        self.model_form = self.model_form_cls(**form_kwargs)
-        self.field_names = list(self.model_form.fields.keys())
-        fields = self.model_form.fields.values()
-        widgets = [field.widget for field in fields]
-        widget = EmbeddedModelWidget(self.field_names, widgets)
-        super().__init__(*args, fields=fields, widget=widget, require_all_fields=False, **kwargs)
-
-    def compress(self, data_dict):
-        if not data_dict:
-            return None
-        values = dict(zip(self.field_names, data_dict, strict=False))
-        return self.model_form._meta.model(**values)
+        kwargs["widget"] = EmbeddedModelWidget(prefix)
+        super().__init__(*args, **kwargs)
 
     def get_bound_field(self, form, field_name):
-        # Nested embedded model form fields need a double prefix.
-        prefix_override = f"{form.prefix}-{self.model_form.prefix}" if form.prefix else None
-        return EmbeddedModelBoundField(form, self, field_name, prefix_override)
+        return EmbeddedModelBoundField(form, self, field_name)
 
-    def bound_data(self, data, initial):
-        if self.disabled:
-            return initial
-        # Transform the bound data into a model instance.
-        return self.compress(data)
-
-    def prepare_value(self, value):
-        # When rendering a form with errors, nested EmbeddedModelField data
-        # won't be compressed if MultiValueField.clean() raises ValidationError
-        # error before compress() is called. The data must be compressed here
-        # so that EmbeddedModelBoundField.value() returns a model instance
-        # (rather than a list) for initializing the form in
-        # EmbeddedModelBoundField.__str__().
-        return self.compress(value) if isinstance(value, list) else value
+    def _clean_bound_field(self, bf):
+        nested_form = bf.nested_form
+        # If the user didn't submit any data, the embedded model is either
+        # omitted (if allowed) or the whole field is flagged as required. In
+        # neither case is there a subfield to highlight, so any message belongs
+        # at the parent level.
+        if not bf.has_data():
+            if self.required:
+                raise ValidationError(self.error_messages["required"], code="required")
+            return None
+        if not nested_form.is_valid():
+            # Surface the nested form's per-field messages in the parent form's
+            # errors dict (so form.errors[name] stays meaningful), but
+            # EmbeddedModelBoundField.errors suppresses them at render time so
+            # they aren't repeated at the parent level: they render inline next
+            # to each offending subfield (via the bound form rendered by
+            # EmbeddedModelBoundField.__str__()).
+            raise ValidationError(list(chain.from_iterable(nested_form.errors.values())))
+        return self.model(**nested_form.cleaned_data)
 
 
 class EmbeddedModelBoundField(forms.BoundField):
-    def __init__(self, form, field, name, prefix_override=None):
+    def __init__(self, form, field, name):
         super().__init__(form, field, name)
-        # prefix_override overrides the prefix in self.field.form_kwargs so
-        # that nested embedded model form elements have the correct name.
-        self.prefix_override = prefix_override
+        # Nested embedded model form fields need a double prefix so that their
+        # subfields are namespaced under the parent form's prefix.
+        prefix = f"{form.prefix}-{field.prefix}" if form.prefix else field.prefix
+        # Bind the nested model form to the submitted data only if the user
+        # provided some; otherwise it's unbound so that an omitted (e.g.
+        # nullable) embedded model doesn't render spurious "required" errors.
+        # This single nested form instance is the source of truth for both
+        # validation (EmbeddedModelField._clean_bound_field()) and rendering
+        # (__str__()); BoundField caching guarantees it's reused.
+        bound = form.is_bound and self.has_data()
+        self.nested_form = field.model_form_cls(
+            data=form.data if bound else None,
+            files=form.files if bound else None,
+            instance=self.initial,
+            prefix=prefix,
+        )
+
+    def has_data(self):
+        """Return whether the user submitted any non-empty nested data."""
+        # self.data is the parent form's data filtered to this field's
+        # subfields (see EmbeddedModelWidget.value_from_datadict).
+        return any(self.data.values())
+
+    @property
+    def errors(self):
+        # When the nested form is rendering its own per-field errors, don't
+        # also render them at the parent level. Genuine parent-level messages —
+        # e.g. the whole embedded model being required while empty, where the
+        # nested form is unbound and has no per-field errors — still render.
+        if self.nested_form.is_bound and not self.nested_form.is_valid():
+            return self.form.error_class(renderer=self.form.renderer)
+        return super().errors
 
     def __str__(self):
-        """Render the model form as the representation for this field."""
-        form = self.field.model_form_cls(instance=self.value(), **self.field.form_kwargs)
-        if self.prefix_override:
-            form.prefix = self.prefix_override
-        return mark_safe(f"{form.as_div()}")  # noqa: S308
+        """Render the (possibly bound) nested model form as this field."""
+        return mark_safe(self.nested_form.as_div())  # noqa: S308
 
 
-class EmbeddedModelWidget(forms.MultiWidget):
-    def __init__(self, field_names, *args, **kwargs):
-        self.field_names = field_names
+class EmbeddedModelWidget(forms.Widget):
+    """
+    Extract the nested form's data from the parent form's data. This widget is
+    never rendered; EmbeddedModelBoundField renders the nested form instead.
+    """
+
+    # Render the field wrapped in a <fieldset> with the field's label as its
+    # <legend>, grouping the nested form's subfields.
+    use_fieldset = True
+
+    def __init__(self, prefix, *args, **kwargs):
+        self.prefix = prefix
         super().__init__(*args, **kwargs)
-        # The default widget names are "_0", "_1", etc. Use the field names
-        # instead since that's how they'll be rendered by the model form.
-        self.widgets_names = ["-" + name for name in field_names]
 
-    def decompress(self, value):
-        if value is None:
-            return []
-        # Get the data from `value` (a model) for each field.
-        return [getattr(value, name) for name in self.field_names]
+    def value_from_datadict(self, data, files, name):
+        return {key: value for key, value in data.items() if key.startswith(f"{name}-")}
+
+    def value_omitted_from_data(self, data, files, name):
+        return not any(key.startswith(f"{name}-") for key in data)

--- a/django_mongodb_backend/forms/fields/embedded_model_array.py
+++ b/django_mongodb_backend/forms/fields/embedded_model_array.py
@@ -6,6 +6,20 @@ from django.utils.html import format_html, format_html_join
 
 
 class EmbeddedModelArrayField(forms.Field):
+    """
+    Form field for an array of embedded models, backed by a formset.
+
+    A single bound formset instance (built in EmbeddedModelArrayBoundField) is
+    the source of truth for both validation and rendering, so each per-form
+    validation error renders inline next to the subfield that produced it
+    instead of being aggregated onto this parent field. The formset's messages
+    are still aggregated into the parent form's errors dict (so
+    form.errors[name] stays meaningful), but EmbeddedModelArrayBoundField
+    suppresses the per-form messages at render time to avoid showing them
+    twice. Non-form errors (e.g. exceeding max_num) render once above the
+    formset.
+    """
+
     def __init__(self, model, *, prefix, max_num=None, extra_forms=3, **kwargs):
         self.model = model
         self.prefix = prefix
@@ -19,11 +33,19 @@ class EmbeddedModelArrayField(forms.Field):
         kwargs["widget"] = EmbeddedModelArrayWidget()
         super().__init__(**kwargs)
 
-    def clean(self, value):
-        if not value:
+    def _clean_bound_field(self, bf):
+        formset = bf.formset
+        if not formset.is_bound:
+            # The field was omitted entirely; let model validation enforce
+            # whether that's allowed.
             return []
-        formset = self.formset(value, prefix=self.prefix_override or self.prefix)
         if not formset.is_valid():
+            # Surface the formset's per-form and non-form messages in the
+            # parent form's errors dict (so form.errors[name] stays
+            # meaningful), but EmbeddedModelArrayBoundField suppresses the
+            # per-form messages at render time so they aren't repeated above
+            # the formset: those render inline next to each offending subfield
+            # (non-form errors are rendered once, above the formset).
             raise ValidationError(formset.errors + formset.non_form_errors())
         cleaned_data = []
         for data in formset.cleaned_data:
@@ -39,27 +61,47 @@ class EmbeddedModelArrayField(forms.Field):
         return formset.has_changed()
 
     def get_bound_field(self, form, field_name):
-        # Nested embedded model form fields need a double prefix.
-        # HACK: Setting self.prefix_override makes it available in clean()
-        # which doesn't have access to the form.
-        self.prefix_override = f"{form.prefix}-{self.prefix}" if form.prefix else None
-        return EmbeddedModelArrayBoundField(form, self, field_name, self.prefix_override)
+        return EmbeddedModelArrayBoundField(form, self, field_name)
 
 
 class EmbeddedModelArrayBoundField(forms.BoundField):
-    def __init__(self, form, field, name, prefix_override):
+    def __init__(self, form, field, name):
         super().__init__(form, field, name)
+        # Bind the formset to the submitted data only if the user provided
+        # some. html_name is the namespaced prefix in both the top-level (e.g.
+        # "reviews") and nested (e.g. "products-0-reviews") cases. This single
+        # formset instance is the source of truth for both validation
+        # (EmbeddedModelArrayField._clean_bound_field()) and rendering
+        # (__str__()); BoundField caching guarantees it's reused.
+        bound = form.is_bound and bool(self.data)
         self.formset = field.formset(
-            self.data if form.is_bound else None,
+            self.data if bound else None,
             initial=models_to_dicts(self.initial),
-            prefix=prefix_override if prefix_override else self.html_name,
+            prefix=self.html_name,
         )
+
+    @property
+    def errors(self):
+        # When the formset is rendering its own per-form errors, don't also
+        # render them at the parent level. Parent-level messages — e.g. the
+        # whole array being required while empty, added by model validation
+        # when the formset is valid — still render.
+        if self.formset.is_bound and not self.formset.is_valid():
+            return self.form.error_class(renderer=self.form.renderer)
+        return super().errors
 
     def __str__(self):
         body = format_html_join(
             "\n", "<tbody>{}</tbody>", ((form.as_table(),) for form in self.formset)
         )
-        return format_html("<table>\n{}\n</table>\n{}", body, self.formset.management_form)
+        # Non-form errors (e.g. "Please submit at most N forms.") aren't tied
+        # to a subfield, so render them once above the formset.
+        return format_html(
+            "{}<table>\n{}\n</table>\n{}",
+            self.formset.non_form_errors(),
+            body,
+            self.formset.management_form,
+        )
 
 
 class EmbeddedModelArrayWidget(forms.Widget):

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -59,6 +59,12 @@ Bug fixes
   :lookup:`iendswith`, :lookup:`contains`, :lookup:`icontains`,
   :lookup:`regex`, and :lookup:`iregex`) on non-string fields.
 
+- Fixed form rendering of
+  :class:`~django_mongodb_backend.fields.EmbeddedModelField`
+  and :class:`~django_mongodb_backend.fields.EmbeddedModelArrayField` so that
+  a validation error is shown next to the subfield that caused it rather than
+  being repeated on the parent field.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -65,6 +65,10 @@ Bug fixes
   a validation error is shown next to the subfield that caused it rather than
   being repeated on the parent field.
 
+- Fixed crash when submitting a form that has an
+  :class:`~django_mongodb_backend.fields.EmbeddedModelField` to a model with a
+  :class:`~django_mongodb_backend.fields.EmbeddedModelArrayField`.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/tests/model_forms_/forms.py
+++ b/tests/model_forms_/forms.py
@@ -1,6 +1,6 @@
 from django import forms
 
-from .models import Author, Book, Movie, Store
+from .models import Author, Book, Movie, Retailer, Store
 
 
 class AuthorForm(forms.ModelForm):
@@ -25,3 +25,9 @@ class StoreForm(forms.ModelForm):
     class Meta:
         fields = "__all__"
         model = Store
+
+
+class RetailerForm(forms.ModelForm):
+    class Meta:
+        fields = "__all__"
+        model = Retailer

--- a/tests/model_forms_/models.py
+++ b/tests/model_forms_/models.py
@@ -54,3 +54,8 @@ class Product(EmbeddedModel):
 class Store(models.Model):
     name = models.CharField(max_length=255)
     products = EmbeddedModelArrayField(Product)
+
+
+class Retailer(models.Model):
+    name = models.CharField(max_length=255)
+    product = EmbeddedModelField(Product)

--- a/tests/model_forms_/test_embedded_model.py
+++ b/tests/model_forms_/test_embedded_model.py
@@ -38,7 +38,7 @@ class ModelFormTests(TestCase):
         }
         form = AuthorForm(data, instance=author)
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors["address"], ["Enter all required values."])
+        self.assertEqual(form.errors["address"], ["This field is required."])
 
     def test_invalid_field_data(self):
         """A field's data (state) is too long."""
@@ -59,7 +59,7 @@ class ModelFormTests(TestCase):
             form.errors["address"],
             [
                 "Ensure this value has at most 2 characters (it has 8).",
-                "Enter all required values.",
+                "This field is required.",
             ],
         )
 
@@ -172,7 +172,7 @@ class NestedFormTests(TestCase):
         }
         form = BookForm(data, instance=book)
         self.assertFalse(form.is_valid())
-        self.assertEqual(form.errors["publisher"], ["Enter all required values."])
+        self.assertEqual(form.errors["publisher"], ["This field is required."])
         self.assertHTMLEqual(
             str(form),
             """
@@ -182,11 +182,8 @@ class NestedFormTests(TestCase):
                 required id="id_title">
             </div>
             <div>
-              <fieldset aria-describedby="id_publisher_error">
-                <legend>Publisher:</legend>
-                <ul class="errorlist" id="id_publisher_error">
-                  <li>Enter all required values.</li>
-                </ul>
+              <fieldset>
+                <legend for="id_publisher">Publisher:</legend>
                 <div>
                   <label for="id_publisher-name">Name:</label>
                   <input type="text" name="publisher-name" value="Random House!" maxlength="50"
@@ -194,7 +191,7 @@ class NestedFormTests(TestCase):
                 </div>
                 <div>
                   <fieldset>
-                    <legend>Address:</legend>
+                    <legend for="id_publisher-address">Address:</legend>
                     <div>
                       <label for="id_publisher-address-po_box">PO Box:</label>
                       <input type="text" name="publisher-address-po_box" maxlength="50"
@@ -212,8 +209,13 @@ class NestedFormTests(TestCase):
                     </div>
                     <div>
                       <label for="id_publisher-address-zip_code">Zip code:</label>
-                      <input type="number" name="publisher-address-zip_code"
-                        required id="id_publisher-address-zip_code">
+                      <ul class="errorlist" id="id_publisher-address-zip_code_error">
+                        <li>This field is required.</li>
+                      </ul>
+                      <input type="number" name="publisher-address-zip_code" required
+                        aria-invalid="true"
+                        aria-describedby="id_publisher-address-zip_code_error"
+                        id="id_publisher-address-zip_code">
                     </div>
                   </fieldset>
                 </div>
@@ -252,11 +254,8 @@ class NestedFormTests(TestCase):
                 maxlength="50" required id="id_title">
             </div>
             <div>
-              <fieldset aria-describedby="id_publisher_error">
-                <legend>Publisher:</legend>
-                <ul class="errorlist" id="id_publisher_error">
-                  <li>Ensure this value has at most 2 characters (it has 8).</li>
-                </ul>
+              <fieldset>
+                <legend for="id_publisher">Publisher:</legend>
                 <div>
                   <label for="id_publisher-name">Name:</label>
                   <input type="text" name="publisher-name" value="Random House!"
@@ -264,7 +263,7 @@ class NestedFormTests(TestCase):
                 </div>
                 <div>
                   <fieldset>
-                    <legend>Address:</legend>
+                    <legend for="id_publisher-address">Address:</legend>
                     <div>
                       <label for="id_publisher-address-po_box">PO Box:</label>
                       <input type="text" name="publisher-address-po_box"
@@ -277,8 +276,13 @@ class NestedFormTests(TestCase):
                     </div>
                     <div>
                       <label for="id_publisher-address-state">State:</label>
+                      <ul class="errorlist" id="id_publisher-address-state_error">
+                        <li>Ensure this value has at most 2 characters (it has 8).</li>
+                      </ul>
                       <input type="text" name="publisher-address-state" value="TOO LONG"
-                        maxlength="2" required id="id_publisher-address-state">
+                        maxlength="2" required aria-invalid="true"
+                        aria-describedby="id_publisher-address-state_error"
+                        id="id_publisher-address-state">
                     </div>
                     <div>
                       <label for="id_publisher-address-zip_code">Zip code:</label>
@@ -323,7 +327,7 @@ class NestedFormTests(TestCase):
             </div>
             <div>
               <fieldset>
-                <legend>Address:</legend>
+                <legend for="id_publisher-address">Address:</legend>
                 <div>
                   <label for="id_publisher-address-po_box">PO Box:</label>
                   <input type="text" name="publisher-address-po_box" maxlength="50"

--- a/tests/model_forms_/test_embedded_model.py
+++ b/tests/model_forms_/test_embedded_model.py
@@ -1,7 +1,7 @@
 from django.test import TestCase
 
-from .forms import AuthorForm, BookForm
-from .models import Address, Author, Book, Publisher
+from .forms import AuthorForm, BookForm, RetailerForm
+from .models import Address, Author, Book, Product, Publisher, Retailer, Review
 
 
 class ModelFormTests(TestCase):
@@ -350,4 +350,205 @@ class NestedFormTests(TestCase):
                 </div>
               </fieldset>
             </div>""",
+        )
+
+
+class NestedEmbeddedArrayFormTests(TestCase):
+    """
+    Tests for EmbeddedModelField → EmbeddedModel with EmbeddedModelArrayField
+    (Retailer → Product → [Review]).
+    """
+
+    def test_create(self):
+        data = {
+            "name": "Acme Retail",
+            "product-name": "TV",
+            "product-reviews-0-title": "Great",
+            "product-reviews-0-rating": "9",
+            "product-reviews-TOTAL_FORMS": 2,
+            "product-reviews-INITIAL_FORMS": 0,
+        }
+        form = RetailerForm(data)
+        self.assertTrue(form.is_valid())
+        retailer = form.save()
+        self.assertEqual(retailer.name, "Acme Retail")
+        self.assertEqual(retailer.product.name, "TV")
+        self.assertEqual(len(retailer.product.reviews), 1)
+        self.assertEqual(retailer.product.reviews[0].title, "Great")
+        self.assertEqual(retailer.product.reviews[0].rating, 9)
+
+    def test_update(self):
+        retailer = Retailer.objects.create(
+            name="Acme Retail",
+            product=Product(name="TV", reviews=[Review(title="Great", rating=9)]),
+        )
+        data = {
+            "name": "Acme Retail!",
+            "product-name": "TV!",
+            "product-reviews-0-title": "Great!",
+            "product-reviews-0-rating": "10",
+            "product-reviews-TOTAL_FORMS": 2,
+            "product-reviews-INITIAL_FORMS": 1,
+        }
+        form = RetailerForm(data, instance=retailer)
+        self.assertTrue(form.is_valid())
+        form.save()
+        retailer.refresh_from_db()
+        self.assertEqual(retailer.name, "Acme Retail!")
+        self.assertEqual(retailer.product.name, "TV!")
+        self.assertEqual(len(retailer.product.reviews), 1)
+        self.assertEqual(retailer.product.reviews[0].title, "Great!")
+        self.assertEqual(retailer.product.reviews[0].rating, 10)
+
+    def test_some_missing_data(self):
+        """A required field (Review.title) is missing."""
+        retailer = Retailer.objects.create(
+            name="Acme Retail",
+            product=Product(name="TV", reviews=[Review(title="Great", rating=9)]),
+        )
+        data = {
+            "name": "Acme Retail",
+            "product-name": "TV",
+            "product-reviews-0-title": "",
+            "product-reviews-0-rating": "9",
+            "product-reviews-TOTAL_FORMS": 2,
+            "product-reviews-INITIAL_FORMS": 1,
+        }
+        form = RetailerForm(data, instance=retailer)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["product"], ["This field is required."])
+
+    def test_invalid_field_data(self):
+        """A field's data (Review.rating) is invalid."""
+        retailer = Retailer.objects.create(
+            name="Acme Retail",
+            product=Product(name="TV", reviews=[Review(title="Great", rating=9)]),
+        )
+        data = {
+            "name": "Acme Retail",
+            "product-name": "TV",
+            "product-reviews-0-title": "Great",
+            "product-reviews-0-rating": "not a number",
+            "product-reviews-TOTAL_FORMS": 2,
+            "product-reviews-INITIAL_FORMS": 1,
+        }
+        form = RetailerForm(data, instance=retailer)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(form.errors["product"], ["Enter a whole number."])
+        self.assertHTMLEqual(
+            str(form),
+            """
+            <div>
+              <label for="id_name">Name:</label>
+              <input type="text" name="name" value="Acme Retail" maxlength="255"
+                required id="id_name">
+            </div>
+            <div>
+              <fieldset>
+                <legend for="id_product">Product:</legend>
+                <div>
+                  <label for="id_product-name">Name:</label>
+                  <input type="text" name="product-name" value="TV"
+                    maxlength="255" required id="id_product-name">
+                </div>
+                <div>
+                  <label for="id_product-reviews">Reviews:</label>
+                  <table>
+                    <tbody>
+                      <tr>
+                        <th>
+                          <label for="id_product-reviews-0-title">Title:</label>
+                        </th>
+                        <td>
+                          <input type="text" name="product-reviews-0-title"
+                            value="Great" maxlength="255"
+                            id="id_product-reviews-0-title">
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>
+                          <label for="id_product-reviews-0-rating">Rating:</label>
+                        </th>
+                        <td>
+                          <ul class="errorlist"
+                            id="id_product-reviews-0-rating_error">
+                            <li>Enter a whole number.</li>
+                          </ul>
+                          <input type="number" name="product-reviews-0-rating"
+                            value="not a number" aria-invalid="true"
+                            aria-describedby="id_product-reviews-0-rating_error"
+                            id="id_product-reviews-0-rating">
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>
+                          <label for="id_product-reviews-0-DELETE">Delete:</label>
+                        </th>
+                        <td>
+                          <input type="checkbox" name="product-reviews-0-DELETE"
+                            id="id_product-reviews-0-DELETE">
+                        </td>
+                      </tr>
+                    </tbody>
+                    <tbody>
+                      <tr>
+                        <th>
+                          <label for="id_product-reviews-1-title">Title:</label>
+                        </th>
+                        <td>
+                          <input type="text" name="product-reviews-1-title"
+                            maxlength="255" id="id_product-reviews-1-title">
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>
+                          <label for="id_product-reviews-1-rating">Rating:</label>
+                        </th>
+                        <td>
+                          <input type="number" name="product-reviews-1-rating"
+                            id="id_product-reviews-1-rating">
+                        </td>
+                      </tr>
+                      <tr>
+                        <th>
+                          <label for="id_product-reviews-1-DELETE">Delete:</label>
+                        </th>
+                        <td>
+                          <input type="checkbox" name="product-reviews-1-DELETE"
+                            id="id_product-reviews-1-DELETE">
+                        </td>
+                      </tr>
+                    </tbody>
+                  </table>
+                  <input type="hidden" name="product-reviews-TOTAL_FORMS"
+                    value="2" id="id_product-reviews-TOTAL_FORMS">
+                  <input type="hidden" name="product-reviews-INITIAL_FORMS"
+                    value="1" id="id_product-reviews-INITIAL_FORMS">
+                  <input type="hidden" name="product-reviews-MIN_NUM_FORMS"
+                    id="id_product-reviews-MIN_NUM_FORMS">
+                  <input type="hidden" name="product-reviews-MAX_NUM_FORMS"
+                    id="id_product-reviews-MAX_NUM_FORMS">
+                </div>
+              </fieldset>
+            </div>""",
+        )
+
+    def test_all_missing_data(self):
+        """All Review fields are empty."""
+        retailer = Retailer.objects.create(
+            name="Acme Retail",
+            product=Product(name="TV", reviews=[Review(title="Great", rating=9)]),
+        )
+        data = {
+            "name": "Acme Retail",
+            "product-name": "TV",
+            "product-reviews-0-title": "",
+            "product-reviews-0-rating": "",
+            "product-reviews-TOTAL_FORMS": 2,
+            "product-reviews-INITIAL_FORMS": 1,
+        }
+        form = RetailerForm(data, instance=retailer)
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form.errors["product"], ["This field is required.", "This field is required."]
         )

--- a/tests/model_forms_/test_embedded_model_array.py
+++ b/tests/model_forms_/test_embedded_model_array.py
@@ -565,9 +565,6 @@ class NestedFormTests(TestCase):
 </div>
 <div>
   <label for="id_products">Products:</label>
-  <ul class="errorlist" id="id_products_error">
-    <li>This field is required.</li>
-  </ul>
   <table>
     <tbody>
       <tr>
@@ -580,9 +577,6 @@ class NestedFormTests(TestCase):
       <tr>
         <th><label for="id_products-0-reviews">Reviews:</label></th>
         <td>
-          <ul class="errorlist" id="id_products-0-reviews_error">
-            <li>This field is required.</li>
-          </ul>
           <table>
             <tbody>
               <tr>


### PR DESCRIPTION
INTPYTHON-643

Claude's analysis:

**Root cause**

`forms.EmbeddedModelField` subclasses `forms.MultiValueField`. That single choice causes every symptom in the ticket:

1. Messages collapse onto the parent. `MultiValueField` is designed to represent one logical value split across several widgets (think split date/time). By contract, all subfield errors are aggregated into the parent field's errorlist — so `form.errors["publisher"]` gets `["Ensure this value has at most 2 characters (it has 8)."]` and it renders in a single `id_publisher_error` `<ul>` at the fieldset level, with no indication that state was the culprit.
2. Wrong/no field highlighting. Rendering is hijacked by `EmbeddedModelBoundField.__str__()`, which builds a fresh, unbound model form: `self.field.model_form_cls(instance=self.value(), ...)`. Because it's unbound (`instance=`, never `data=`), the nested form has no errors of its own, so Django can't add aria-invalid/error classes to the offending inputs. The fields that are actually wrong are never marked.
  3. Generic, useless messages. `"Enter all required values."` / `"Enter a list of values."` are `MultiValueField`'s incomplete/invalid messages — they don't name the missing subfield.

The same bug exists, in worse form, in `EmbeddedModelArrayField`: `clean()` raises `ValidationError(formset.errors + formset.non_form_errors())` (aggregating onto the parent), and `EmbeddedModelArrayBoundField.__str__()` renders a bound formset that shows per-field errors too → messages are literally rendered twice.

**Why this is the wrong abstraction**

`MultiValueField`/`MultiWidget` has no concept of per-subwidget errors — there is no template hook to attach an error to widget N. The structure that does have native per-field error association is a bound form (or formset): each `BoundField` renders its own errors next to its input and marks the input invalid. Django already does this perfectly; we just aren't letting it.

**Recommended solution**

Stop using `MultiValueField`. Make `EmbeddedModelField` a plain `forms.Field` that owns a real, bound nested `ModelForm` and delegates both validation and rendering to it — mirroring (and then unifying with) the `EmbeddedModelArrayField`/formset design, which is already the right shape.

The enabling hook is `Field._clean_bound_field(self, bf)`. Unlike `clean(value)`, it receives the `BoundField` — so the same nested form built for rendering can be the one we validate. That gives a single source of truth and lets us delete the prefix_override HACK.

---

This improves the situation and solves INTPYTHON-993 as a side-effect (commit two has regression tests), but it doesn't solve all layout and styling issues. I created INTPYTHON-995 for follow up.