### PR TITLE
Rework embedded model resolution on cloned fields when querying

### DIFF
--- a/django_mongodb_backend/fields/embedded_model.py
+++ b/django_mongodb_backend/fields/embedded_model.py
@@ -1,6 +1,5 @@
 import difflib
 
-from django.apps import apps
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models
@@ -125,19 +124,19 @@ class EmbeddedModelField(models.Field):
         embedded_instance._state.adding = False
         return field_values
 
-    @cached_property
-    def resolved_embedded_model(self):
-        # Since Field.deconstruct() serializes self.embedded_model as a string,
-        # it may need to be resolved after a Field.clone() in querying.
-        model = self.embedded_model
-        return apps.get_model(model) if isinstance(model, str) else model
-
     def get_transform(self, name):
         transform = super().get_transform(name)
         if transform:
             return transform
-        field = self.resolved_embedded_model._meta.get_field(name)
+        field = self.embedded_model._meta.get_field(name)
         return EmbeddedModelTransformFactory(field)
+
+    def copy_resolved_embedded_models(self, source):
+        # (Polymorphic)EmbeddedModelArrayFieldTransform clones the target field
+        # which makes the embedded_model attribute a string via
+        # Field.deconstruct(). The actual model class be must set on the cloned
+        # field.
+        self.embedded_model = source.embedded_model
 
     def validate(self, value, model_instance):
         super().validate(value, model_instance)

--- a/django_mongodb_backend/fields/embedded_model_array.py
+++ b/django_mongodb_backend/fields/embedded_model_array.py
@@ -72,8 +72,13 @@ class EmbeddedModelArrayField(NoEncryptedEmbeddedFieldsMixin, ArrayField):
         transform = super().get_transform(name)
         if transform:
             return transform
-        field = self.base_field.resolved_embedded_model._meta.get_field(name)
+        field = self.base_field.embedded_model._meta.get_field(name)
         return EmbeddedModelArrayFieldTransformFactory(field)
+
+    def copy_resolved_embedded_models(self, source):
+        # Only the base field's embedded_model is read when querying, so the
+        # array field's own embedded_model attribute doesn't need to be copied.
+        self.base_field.copy_resolved_embedded_models(source.base_field)
 
     def _get_lookup(self, lookup_name):
         lookup = super()._get_lookup(lookup_name)
@@ -225,6 +230,11 @@ class EmbeddedModelArrayFieldTransform(Transform):
         column_name = f"${self.VIRTUAL_COLUMN_ITERABLE}.{field.column}"
         column_target.db_column = column_name
         column_target.set_attributes_from_name(column_name)
+        # Copy the resolved embedded_model/embedded_models attribute to the
+        # cloned field, replacing the strings set by field.clone() via
+        # deconstruct().
+        if hasattr(field, "copy_resolved_embedded_models"):
+            column_target.copy_resolved_embedded_models(field)
         self._field = field
         self._lhs = Col(None, column_target)
         self._sub_transform = None

--- a/django_mongodb_backend/fields/polymorphic_embedded_model.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model.py
@@ -1,11 +1,9 @@
 import contextlib
 
-from django.apps import apps
 from django.core import checks
 from django.core.exceptions import FieldDoesNotExist, ValidationError
 from django.db import models
 from django.db.models.fields.related import lazy_related_operation
-from django.utils.functional import cached_property
 
 from .embedded_model import EmbeddedModelTransformFactory
 from .utils import get_mongodb_connection, serialize_model_reference
@@ -154,21 +152,11 @@ class PolymorphicEmbeddedModelField(models.Field):
         embedded_instance._state.adding = False
         return field_values
 
-    @cached_property
-    def resolved_embedded_models(self):
-        # Since Field.deconstruct() serializes self.embedded_models as a list
-        # of strings, these strings may need to be resolved after a
-        # Field.clone() in querying.
-        return tuple(
-            apps.get_model(model) if isinstance(model, str) else model
-            for model in self.embedded_models
-        )
-
     def get_transform(self, name):
         transform = super().get_transform(name)
         if transform:
             return transform
-        for model in self.resolved_embedded_models:
+        for model in self.embedded_models:
             with contextlib.suppress(FieldDoesNotExist):
                 field = model._meta.get_field(name)
                 break
@@ -177,6 +165,13 @@ class PolymorphicEmbeddedModelField(models.Field):
                 f"The models of field '{self.name}' have no field named '{name}'."
             )
         return EmbeddedModelTransformFactory(field)
+
+    def copy_resolved_embedded_models(self, source):
+        # (Polymorphic)EmbeddedModelArrayFieldTransform clones the target field
+        # which makes the embedded_model attribute a string via
+        # Field.deconstruct(). The actual model classes be must set on the
+        # cloned field.
+        self.embedded_models = source.embedded_models
 
     def validate(self, value, model_instance):
         super().validate(value, model_instance)

--- a/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
+++ b/django_mongodb_backend/fields/polymorphic_embedded_model_array.py
@@ -69,7 +69,7 @@ class PolymorphicEmbeddedModelArrayField(ArrayField):
         transform = super().get_transform(name)
         if transform:
             return transform
-        for model in self.base_field.resolved_embedded_models:
+        for model in self.base_field.embedded_models:
             with contextlib.suppress(FieldDoesNotExist):
                 field = model._meta.get_field(name)
                 break
@@ -78,6 +78,11 @@ class PolymorphicEmbeddedModelArrayField(ArrayField):
                 f"The models of field '{self.name}' have no field named '{name}'."
             )
         return PolymorphicArrayFieldTransformFactory(field)
+
+    def copy_resolved_embedded_models(self, source):
+        # Only the base field's embedded_models is read when querying, so the
+        # array field's own embedded_model attribute doesn't need to be copied.
+        self.base_field.copy_resolved_embedded_models(source.base_field)
 
     def _get_lookup(self, lookup_name):
         lookup = super()._get_lookup(lookup_name)
@@ -107,6 +112,11 @@ class PolymorphicArrayFieldTransform(EmbeddedModelArrayFieldTransform):
         column_target.name = f"{field.name}"
         column_target.db_column = column_name
         column_target.set_attributes_from_name(column_name)
+        # Copy the resolved embedded_model/embedded_models attribute to the
+        # cloned field, replacing the strings set by field.clone() via
+        # deconstruct().
+        if hasattr(field, "copy_resolved_embedded_models"):
+            column_target.copy_resolved_embedded_models(field)
         self._lhs = Col(None, column_target)
         self._sub_transform = None
 


### PR DESCRIPTION
`Field.deconstruct()` serializes embedded model references to strings so that migrations migrations don't hardcode model classes (INTPYTHON-916). Array transforms clone the embedded field (which uses `deconstruct()`) to build a virtual column. Since that clone isn't attached to a model, `contribute_to_class()` never resolves the string back to a class.

The `resolved_embedded_model`/`resolved_embedded_models` approach from a766be5408c9129972b99b99edec21b58b75fc9f cached properties worked around this by re-resolving via the global app registry, but that's incorrect during migrations, which use a separate state (historical) app registry.

Instead, copy the already-resolved class(es) from the source field -- which `contribute_to_class()` resolved against the correct registry -- onto its clone in the transform, via a new `copy_resolved_embedded_models()` method on each embedded model field. No registry lookup is needed, so it's correct in both the global and historical cases.