### PR TITLE
INTPYTHON-992 Make Sum return None instead of 0 when no rows match

### DIFF
--- a/django_mongodb_backend/aggregates.py
+++ b/django_mongodb_backend/aggregates.py
@@ -4,6 +4,7 @@ from django.db.models.aggregates import (
     Count,
     StdDev,
     StringAgg,
+    Sum,
     Variance,
 )
 from django.db.models.expressions import Case, Value, When
@@ -91,9 +92,36 @@ def string_agg(self, compiler, connection, resolve_inner_expression=False):  # n
     raise NotSupportedError("StringAgg is not supported.")
 
 
+def sum_(self, compiler, connection, resolve_inner_expression=False):
+    """
+    Use $push (not $sum) in the group stage so that _get_replace_expr() can use
+    NullSafeArraySum in the project stage, returning None instead of 0 when no
+    rows contribute, matching SQL SUM() null semantics.
+
+    A null check is added so that null values produce $$REMOVE, causing $push
+    to skip them. This keeps the array empty when all values are null, letting
+    NullSafeArraySum distinguish "no non-null values" (None) from "values
+    summing to 0" (0).
+    """
+    agg_expression, *_ = self.get_source_expressions()
+    # Always check for nulls; add the filter condition when present.
+    conditions = [IsNull(agg_expression, False)]
+    if self.filter:
+        conditions.append(self.filter.condition)
+    agg_expression = Case(
+        When(WhereNode(conditions), then=agg_expression),
+        default=Remove(),
+    )
+    lhs_mql = agg_expression.as_mql(compiler, connection, as_expr=True)
+    if resolve_inner_expression:
+        return lhs_mql
+    return {"$push": lhs_mql}
+
+
 def register_aggregates():
     Aggregate.as_mql_expr = aggregate
     Count.as_mql_expr = count
     StdDev.as_mql_expr = stddev_variance
     StringAgg.as_mql_expr = string_agg
+    Sum.as_mql_expr = sum_
     Variance.as_mql_expr = stddev_variance

--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -6,7 +6,7 @@ from bson import SON, ObjectId, json_util
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import IntegrityError, NotSupportedError
 from django.db.models import Count
-from django.db.models.aggregates import Aggregate, Variance
+from django.db.models.aggregates import Aggregate, Sum, Variance
 from django.db.models.expressions import Case, Col, OrderBy, Ref, RowRange, Value, When, Window
 from django.db.models.functions.comparison import Coalesce
 from django.db.models.functions.math import Power
@@ -18,6 +18,7 @@ from django.db.models.sql.where import AND, OR, XOR, ExtraWhere, NothingNode, Wh
 from django.utils.functional import cached_property
 from pymongo import ASCENDING, DESCENDING
 
+from .expressions import NullSafeArraySum
 from .expressions.search import SearchExpression, SearchVector
 from .query import MongoQuery, wrap_database_errors
 from .query_utils import is_constant_value, is_direct_value
@@ -80,11 +81,19 @@ class SQLCompiler(compiler.SQLCompiler):
                 self, self.connection, resolve_inner_expression=True, as_expr=True
             )
             group[alias] = {"$addToSet": rhs}
-            replacing_expr = sub_expr.copy()
-            replacing_expr.set_source_expressions([inner_column, None])
+            if isinstance(sub_expr, Sum):
+                # NullSafeArraySum returns None instead of 0 when no values
+                # are accumulated.
+                replacing_expr = NullSafeArraySum(inner_column)
+            else:
+                replacing_expr = sub_expr.copy()
+                replacing_expr.set_source_expressions([inner_column, None])
         else:
             group[alias] = sub_expr.as_mql(self, self.connection, as_expr=True)
-            replacing_expr = inner_column
+            if isinstance(sub_expr, Sum):
+                replacing_expr = NullSafeArraySum(inner_column)
+            else:
+                replacing_expr = inner_column
         # Count must return 0 rather than null.
         if isinstance(sub_expr, Count):
             replacing_expr = Coalesce(replacing_expr, 0)
@@ -336,7 +345,7 @@ class SQLCompiler(compiler.SQLCompiler):
         search_replacements = self._prepare_search_query_for_aggregation_pipeline(order_by)
         group, group_replacements = self._prepare_annotations_for_aggregation_pipeline(order_by)
         window_stages, window_replacements = self._prepare_window_annotations_for_pipeline()
-        all_replacements = {**search_replacements, **group_replacements, **window_replacements}
+        all_replacements = {**search_replacements, **window_replacements, **group_replacements}
         self.search_pipeline = self._compound_searches_queries(search_replacements)
         # query.group_by is either:
         # - None: no GROUP BY

--- a/django_mongodb_backend/expressions/__init__.py
+++ b/django_mongodb_backend/expressions/__init__.py
@@ -1,4 +1,4 @@
-from .expressions import Remove
+from .expressions import NullSafeArraySum, Remove
 from .search import (
     CombinedSearchExpression,
     CompoundExpression,
@@ -22,6 +22,7 @@ from .search import (
 __all__ = [
     "CombinedSearchExpression",
     "CompoundExpression",
+    "NullSafeArraySum",
     "Remove",
     "SearchAutocomplete",
     "SearchEquals",

--- a/django_mongodb_backend/expressions/expressions.py
+++ b/django_mongodb_backend/expressions/expressions.py
@@ -1,6 +1,30 @@
 from django.db.models.expressions import Func
 
 
+class NullSafeArraySum(Func):
+    """
+    Compute the sum of an array column, returning None if the array is empty.
+    Used as the project-stage replacement for Sum to match SQL SUM() semantics
+    (NULL for no rows, rather than MongoDB's $sum returning 0).
+    """
+
+    def as_mql(self, compiler, connection, as_expr=False):
+        col_expr = self.source_expressions[0]
+        # When a collection is empty, the wrapping stage injects an empty
+        # document to support default= on aggregates — that document has no
+        # array field at all, so $size gets missing type. $ifNull guards
+        # against that.
+        array_mql = {"$ifNull": [col_expr.as_mql(compiler, connection, as_expr=True), []]}
+        mql = {
+            "$cond": [
+                {"$eq": [{"$size": array_mql}, 0]},
+                None,
+                {"$sum": array_mql},
+            ]
+        }
+        return mql if as_expr else {"$expr": mql}
+
+
 class Remove(Func):
     def as_mql(self, compiler, connection, as_expr=False):
         return "$$REMOVE"

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -78,13 +78,6 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
         "annotations.tests.NonAggregateAnnotationTestCase.test_combined_f_expression_annotation_with_aggregation",
         # Unexpected alias_refcount in alias_map.
         "queries.tests.Queries1Tests.test_order_by_tables",
-        # The $sum aggregation returns 0 instead of None for null.
-        "aggregation.test_filter_argument.FilteredAggregateTests.test_plain_annotate",
-        "aggregation.tests.AggregateTestCase.test_aggregation_default_passed_another_aggregate",
-        "aggregation.tests.AggregateTestCase.test_annotation_expressions",
-        "aggregation.tests.AggregateTestCase.test_reverse_fkey_annotate",
-        "aggregation_regress.tests.AggregationTests.test_annotation_disjunction",
-        "aggregation_regress.tests.AggregationTests.test_decimal_aggregate_annotation_filter",
         # subclasses of BaseDatabaseWrapper may require an is_usable() method
         "backends.tests.BackendTestCase.test_is_usable_after_database_disconnects",
         # Connection creation doesn't follow the usual Django API.

--- a/django_mongodb_backend/functions/window.py
+++ b/django_mongodb_backend/functions/window.py
@@ -1,4 +1,4 @@
-from django.db.models.aggregates import Aggregate, Count, StdDev, Variance
+from django.db.models.aggregates import Aggregate, Count, StdDev, Sum, Variance
 from django.db.models.functions.window import (
     CumeDist,
     DenseRank,
@@ -213,6 +213,25 @@ def stddev(self, compiler, connection, alias, idx, default_frame):  # noqa: ARG0
     return {alias: {**agg_mql, "window": default_frame()}}, {}
 
 
+def sum_window(self, compiler, connection, alias, idx, default_frame):
+    # Sum.as_mql_expr() uses $push (not $sum) so SQL SUM() null semantics can
+    # be honored. Collect the pushed values in the window, then reduce them to
+    # a null-safe sum in $addFields. Return None when no rows contribute.
+    agg_mql = self.as_mql_expr(compiler, connection)
+    push_alias = f"__wtemp{next(idx)}"
+    output = {push_alias: {**agg_mql, "window": default_frame()}}
+    add_fields = {
+        alias: {
+            "$cond": [
+                {"$eq": [{"$size": f"${push_alias}"}, 0]},
+                None,
+                {"$sum": f"${push_alias}"},
+            ]
+        }
+    }
+    return output, add_fields
+
+
 def variance(self, compiler, connection, alias, idx, default_frame):
     # MongoDB has no $varPop/$varSamp window accumulator; compute as stdDev².
     agg_mql = self.as_mql_expr(compiler, connection)
@@ -237,4 +256,5 @@ def register_window():
     Rank.get_window_mql = rank
     RowNumber.get_window_mql = row_number
     StdDev.get_window_mql = stddev
+    Sum.get_window_mql = sum_window
     Variance.get_window_mql = variance

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -78,6 +78,9 @@ Bug fixes
 - Prevented aggregation queries from generating redundant accumulators in the
   ``$group`` stage.
 
+- Made the :class:`~django.db.models.Sum` aggregation function return ``None``
+  instead of ``0`` when no rows match, matching SQL semantics.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/tests/lookup_/tests.py
+++ b/tests/lookup_/tests.py
@@ -108,11 +108,61 @@ class LookupMQLTests(MongoTestCaseMixin, TestCase):
             ctx.captured_queries[0]["sql"],
             "lookup__number",
             [
-                {"$group": {"_id": {"num": "$num"}, "total": {"$sum": "$num"}}},
+                {
+                    "$group": {
+                        "total": {
+                            "$push": {
+                                "$switch": {
+                                    "branches": [
+                                        {
+                                            "case": {
+                                                "$not": {
+                                                    "$or": [
+                                                        {"$eq": [{"$type": "$num"}, "missing"]},
+                                                        {"$eq": ["$num", None]},
+                                                    ]
+                                                }
+                                            },
+                                            "then": "$num",
+                                        }
+                                    ],
+                                    "default": "$$REMOVE",
+                                }
+                            }
+                        },
+                        "_id": {"num": "$num"},
+                    }
+                },
                 {"$addFields": {"num": "$_id.num"}},
                 {"$unset": "_id"},
-                {"$match": {"total": 1}},
-                {"$project": {"num": 1, "total": 1}},
+                {
+                    "$match": {
+                        "$expr": {
+                            "$eq": [
+                                {
+                                    "$cond": [
+                                        {"$eq": [{"$size": {"$ifNull": ["$total", []]}}, 0]},
+                                        None,
+                                        {"$sum": {"$ifNull": ["$total", []]}},
+                                    ]
+                                },
+                                1,
+                            ]
+                        }
+                    }
+                },
+                {
+                    "$project": {
+                        "total": {
+                            "$cond": [
+                                {"$eq": [{"$size": {"$ifNull": ["$total", []]}}, 0]},
+                                None,
+                                {"$sum": {"$ifNull": ["$total", []]}},
+                            ]
+                        },
+                        "num": 1,
+                    }
+                },
                 {"$sort": SON([("num", 1)])},
             ],
         )


### PR DESCRIPTION
Example fixed queries:

1. Publisher "Jonno's House of Books" has no books, so currently returns 0 instead of None.
```python
publishers = Publisher.objects.annotate(Sum("book__price")).order_by("name")
self.assertQuerySetEqual(
    publishers,
    [
        ("Apress", Decimal("59.69")),
        ("Jonno's House of Books", None),
        ("Morgan Kaufmann", Decimal("75.00")),
        ("Prentice Hall", Decimal("112.49")),
        ("Sams", Decimal("23.09")),
    ],
    lambda p: (p.name, p.book__price__sum),
)
```


2. Currently "Jonno's House of Books" does not appear in the results since its `rating_sum` is 0 instead of null.
```python
qs = (
    Publisher.objects.annotate(
        rating_sum=Sum("book__rating"), book_count=Count("book")
    )
    .filter(Q(rating_sum__gt=5.5) | Q(rating_sum__isnull=True))
    .order_by("pk")
)
self.assertQuerySetEqual(
    qs,
    [
        "Apress",
        "Prentice Hall",
        "Jonno's House of Books",
    ],
    attrgetter("name"),
)
````