### PR TITLE
INTPYTHON-999 Add support for StringAgg

### DIFF
--- a/django_mongodb_backend/aggregates.py
+++ b/django_mongodb_backend/aggregates.py
@@ -7,7 +7,7 @@ from django.db.models.aggregates import (
     Sum,
     Variance,
 )
-from django.db.models.expressions import Case, Value, When
+from django.db.models.expressions import Case, OrderBy, Value, When
 from django.db.models.functions.comparison import Coalesce
 from django.db.models.lookups import IsNull
 from django.db.models.sql.where import WhereNode
@@ -88,8 +88,25 @@ def stddev_variance(self, compiler, connection):
     return aggregate(self, compiler, connection, operator=operator)
 
 
-def string_agg(self, compiler, connection, resolve_inner_expression=False):  # noqa: ARG001
-    raise NotSupportedError("StringAgg is not supported.")
+def string_agg(self, compiler, connection, resolve_inner_expression=False):
+    agg_expression, *_ = self.get_source_expressions()
+    if self.filter is not None:
+        agg_expression = Case(
+            When(self.filter.condition, then=agg_expression),
+            default=Remove(),
+        )
+    lhs_mql = agg_expression.as_mql(compiler, connection, as_expr=True)
+    if resolve_inner_expression:
+        return lhs_mql
+    if self.order_by:
+        # Push {v: value, k0: sort_key, ...} so StringAggJoin can sort the
+        # array in the post-group stage using $sortArray.
+        sort_keys = {}
+        for i, expr in enumerate(self.order_by.get_source_expressions()):
+            key_expr = expr.expression if isinstance(expr, OrderBy) else expr
+            sort_keys[f"k{i}"] = key_expr.as_mql(compiler, connection, as_expr=True)
+        return {"$push": {"v": lhs_mql, **sort_keys}}
+    return {"$push": lhs_mql}
 
 
 def sum_(self, compiler, connection, resolve_inner_expression=False):

--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -6,7 +6,7 @@ from bson import SON, ObjectId, json_util
 from django.core.exceptions import EmptyResultSet, FieldError, FullResultSet
 from django.db import IntegrityError, NotSupportedError
 from django.db.models import Count
-from django.db.models.aggregates import Aggregate, Sum, Variance
+from django.db.models.aggregates import Aggregate, StringAgg, Sum, Variance
 from django.db.models.expressions import Case, Col, OrderBy, Ref, RowRange, Value, When, Window
 from django.db.models.functions.comparison import Coalesce
 from django.db.models.functions.math import Power
@@ -18,7 +18,7 @@ from django.db.models.sql.where import AND, OR, XOR, ExtraWhere, NothingNode, Wh
 from django.utils.functional import cached_property
 from pymongo import ASCENDING, DESCENDING
 
-from .expressions import NullSafeArraySum
+from .expressions import NullSafeArraySum, StringAggJoin
 from .expressions.search import SearchExpression, SearchVector
 from .query import MongoQuery, wrap_database_errors
 from .query_utils import is_constant_value, is_direct_value
@@ -100,6 +100,28 @@ class SQLCompiler(compiler.SQLCompiler):
         # Variance = StdDev^2
         if isinstance(sub_expr, Variance):
             replacing_expr = Power(replacing_expr, 2)
+        # StringAgg needs $reduce to join the accumulated array with the
+        # delimiter.
+        elif isinstance(sub_expr, StringAgg):
+            sort_spec = None
+            scalar_sort = None
+            if sub_expr.order_by:
+                if getattr(sub_expr, "distinct", False):
+                    # The group stage used $addToSet, so the array holds plain
+                    # scalar values. Sort them using a scalar direction.
+                    first = sub_expr.order_by.get_source_expressions()[0]
+                    scalar_sort = -1 if isinstance(first, OrderBy) and first.descending else 1
+                else:
+                    sort_spec = [
+                        (f"k{i}", -1 if isinstance(expr, OrderBy) and expr.descending else 1)
+                        for i, expr in enumerate(sub_expr.order_by.get_source_expressions())
+                    ]
+            replacing_expr = StringAggJoin(
+                inner_column,
+                sub_expr.source_expressions[1],
+                sort_spec=sort_spec,
+                scalar_sort=scalar_sort,
+            )
         return replacing_expr
 
     def _prepare_expressions_for_pipeline(

--- a/django_mongodb_backend/expressions/__init__.py
+++ b/django_mongodb_backend/expressions/__init__.py
@@ -1,4 +1,4 @@
-from .expressions import NullSafeArraySum, Remove
+from .expressions import NullSafeArraySum, Remove, StringAggJoin
 from .search import (
     CombinedSearchExpression,
     CompoundExpression,
@@ -39,4 +39,5 @@ __all__ = [
     "SearchText",
     "SearchVector",
     "SearchWildcard",
+    "StringAggJoin",
 ]

--- a/django_mongodb_backend/expressions/expressions.py
+++ b/django_mongodb_backend/expressions/expressions.py
@@ -1,4 +1,5 @@
-from django.db.models.expressions import Func
+from django.db.models.expressions import Expression, Func
+from django.db.models.fields import TextField
 
 
 class NullSafeArraySum(Func):
@@ -28,3 +29,103 @@ class NullSafeArraySum(Func):
 class Remove(Func):
     def as_mql(self, compiler, connection, as_expr=False):
         return "$$REMOVE"
+
+
+class StringAggJoin(Expression):
+    """
+    Post-group expression that joins a $push'd or $addToSet'd array with a
+    delimiter using $reduce/$concat. Return null for empty arrays, consistent
+    with SQL STRING_AGG behavior.
+
+    When sort_spec is provided (list of (field_name, direction) tuples), the
+    pushed array contains {v: value, k0: key, ...} objects. This class then
+    sorts by the key fields and extracts the values before joining.
+
+    When scalar_sort is provided (1 or -1), the array contains plain scalar
+    values (from $addToSet for DISTINCT) and is sorted directly.
+    """
+
+    def __init__(self, array_expr, delimiter_wrapper, sort_spec=None, scalar_sort=None):
+        super().__init__(output_field=TextField())
+        self.array_expr = array_expr
+        self.delimiter_wrapper = delimiter_wrapper
+        self.sort_spec = sort_spec  # e.g. [("k0", 1), ("k1", -1)] or None
+        self.scalar_sort = scalar_sort  # 1 or -1 for DISTINCT + ORDER BY, or None
+
+    def get_source_expressions(self):
+        return [self.array_expr, self.delimiter_wrapper]
+
+    def set_source_expressions(self, exprs):
+        self.array_expr, self.delimiter_wrapper = exprs
+
+    def as_mql_expr(self, compiler, connection):
+        array_mql = self.array_expr.as_mql(compiler, connection, as_expr=True)
+        # StringAggDelimiter wraps the actual delimiter Value; unwrap it.
+        delimiter_mql = self.delimiter_wrapper.get_source_expressions()[0].as_mql(
+            compiler, connection, as_expr=True
+        )
+        if self.sort_spec:
+            # Array contains {v: value, k0: key, ...} objects pushed by
+            # string_agg().
+            sorted_input = {
+                "$sortArray": {
+                    "input": {"$ifNull": [array_mql, []]},
+                    "sortBy": dict(self.sort_spec),
+                }
+            }
+            # Extract v values; rows excluded by a filter have no v field so
+            # $$item.v is null — those are removed by the null check below.
+            filtered = {
+                "$filter": {
+                    "input": {
+                        "$map": {
+                            "input": sorted_input,
+                            "as": "item",
+                            "in": "$$item.v",
+                        }
+                    },
+                    "cond": {"$ne": ["$$this", None]},
+                }
+            }
+        elif self.scalar_sort is not None:
+            # Array contains plain scalar values from $addToSet (DISTINCT
+            # case). Sort the values directly.
+            filtered = {
+                "$filter": {
+                    "input": {
+                        "$sortArray": {
+                            "input": {"$ifNull": [array_mql, []]},
+                            "sortBy": self.scalar_sort,
+                        }
+                    },
+                    "cond": {"$ne": ["$$this", None]},
+                }
+            }
+        else:
+            # Guard against null (missing field from wrapping empty-result
+            # pipelines), and filter out null values (SQL STRING_AGG ignores
+            # nulls).
+            filtered = {
+                "$filter": {
+                    "input": {"$ifNull": [array_mql, []]},
+                    "cond": {"$ne": ["$$this", None]},
+                }
+            }
+        return {
+            "$let": {
+                "vars": {"arr": filtered},
+                "in": {
+                    "$cond": [
+                        {"$gt": [{"$size": "$$arr"}, 0]},
+                        {
+                            "$reduce": {
+                                "input": {"$slice": ["$$arr", 1, {"$size": "$$arr"}]},
+                                "initialValue": {"$arrayElemAt": ["$$arr", 0]},
+                                "in": {"$concat": ["$$value", delimiter_mql, "$$this"]},
+                            }
+                        },
+                        None,
+                    ]
+                },
+            }
+        }

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -24,6 +24,7 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
     has_json_object_function = False
     has_native_json_field = True
     rounds_to_even = True
+    supports_aggregate_order_by_clause = True
     supports_boolean_expr_in_select_clause = True
     supports_collation_on_charfield = False
     supports_column_check_constraints = False
@@ -110,6 +111,9 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
         # connection TIME_ZONE before truncating:
         # https://jira.mongodb.org/browse/INTPYTHON-1009
         "timezones.tests.NewDatabaseTests.test_query_convert_timezones",
+        # Test relies on SQL grouping behavior:
+        # https://github.com/django/django/pull/19489#discussion_r3462766505
+        "aggregation.tests.AggregateTestCase.test_string_agg_filter_outerref",
     }
 
     @cached_property
@@ -691,13 +695,6 @@ class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
             "backends.tests.BackendTestCase.test_cursor_executemany",
             "backends.tests.BackendTestCase.test_cursor_executemany_with_empty_params_list",
             "backends.tests.BackendTestCase.test_cursor_executemany_with_iterator",
-        },
-        (NotSupportedError, "StringAgg is not supported."): {
-            "aggregation.tests.AggregateTestCase.test_distinct_on_stringagg",
-            "aggregation.tests.AggregateTestCase.test_string_agg_escapes_delimiter",
-            "aggregation.tests.AggregateTestCase.test_string_agg_filter",
-            "aggregation.tests.AggregateTestCase.test_string_agg_filter_in_subquery",
-            "aggregation.tests.AggregateTestCase.test_stringagg_default_value",
         },
         (NotSupportedError, "ColPairs is not supported."): {
             "composite_pk.tests.CompositePKTests.test_in_bulk",

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -24,6 +24,8 @@ New features
   - :class:`~django.db.models.functions.SHA256` (requires MongoDB 8.3+)
   - :class:`~django.db.models.functions.Sign`
 
+- Added support for the :class:`~django.db.models.StringAgg` aggregate.
+
 - Added support for fixed-offset ``tzinfo`` in the
   :class:`~django.db.models.functions.Extract` database functions.
 

--- a/docs/topics/known-issues.rst
+++ b/docs/topics/known-issues.rst
@@ -50,9 +50,6 @@ Querying
   :meth:`~django.db.models.query.QuerySet.update` do not support queries that
   span multiple collections.
 
-- The :class:`~django.db.models.StringAgg` aggregation function isn't
-  supported.
-
 - When querying :class:`~django.db.models.JSONField`:
 
   - There is no way to distinguish between a JSON ``"null"`` (represented by


### PR DESCRIPTION
Some assertions in Django's test suite were relaxed to account for the fact that the ordering of results for `STRING_AGG` without `ORDER BY` isn't defined (https://github.com/django/django/pull/21536). The commit has been merged to Django's master and stable/6.1.x branches and backported to the mongodb-6.0.x branch since it won't be backported to Django's stable/6.0.x branch.

Claude review identified some additional test coverage needed: https://github.com/django/django/pull/21559. This will be added to the Django fork branches as well.