### PR TITLE
Remove statement that database caching may be added in a future release

### DIFF
--- a/docs/topics/known-issues.rst
+++ b/docs/topics/known-issues.rst
@@ -97,6 +97,4 @@ Due to the lack of ability to introspect MongoDB collection schema,
 Caching
 =======
 
-:ref:`Database caching <database-caching>` is not supported since Django's built-in
-database cache backend requires SQL. A custom cache backend for MongoDB may be provided
-in the future.
+:ref:`Database caching <database-caching>` is not supported.


### PR DESCRIPTION
INTPYTHON-451 was closed as "won't do" because Django's database caching uses pickle to serialize cached data and this could escalate a cache compromise into a remote-code execution. Mitigations such as signing cached data could be implemented but this has performance implications.