### PR TITLE
INTPYTHON-1004 Avoid duplicate group accumulators for annotated aggregates

### DIFF
--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -93,7 +93,13 @@ class SQLCompiler(compiler.SQLCompiler):
             replacing_expr = Power(replacing_expr, 2)
         return replacing_expr
 
-    def _prepare_expressions_for_pipeline(self, expression, target, annotation_group_idx):
+    def _prepare_expressions_for_pipeline(
+        self,
+        expression,
+        target,
+        annotation_group_idx,
+        existing_replacements=(),
+    ):
         """
         Prepare expressions for the aggregation pipeline.
 
@@ -109,10 +115,17 @@ class SQLCompiler(compiler.SQLCompiler):
         the aggregation first, then apply additional operations in a subsequent
         stage by replacing the aggregate expressions with new columns prefixed
         by `__aggregation`.
+
+        If existing_replacements is provided, sub-expressions already present
+        in it are skipped so they are not re-added to the group stage, avoiding
+        duplicate accumulators when the same aggregate object appears in both
+        an annotation and a having/ordering clause.
         """
         replacements = {}
         group = {}
         for sub_expr in self._get_aggregate_expressions(expression):
+            if sub_expr in existing_replacements:
+                continue
             alias = (
                 f"__aggregation{next(annotation_group_idx)}" if sub_expr != expression else target
             )
@@ -169,19 +182,25 @@ class SQLCompiler(compiler.SQLCompiler):
         for target, expr in self.query.annotation_select.items():
             if expr.contains_aggregate:
                 new_replacements, expr_group = self._prepare_expressions_for_pipeline(
-                    expr, target, annotation_group_idx
+                    expr, target, annotation_group_idx, existing_replacements=replacements
                 )
                 replacements.update(new_replacements)
                 group.update(expr_group)
         for expr, _ in order_by:
             if expr.contains_aggregate:
                 new_replacements, expr_group = self._prepare_expressions_for_pipeline(
-                    expr, None, annotation_group_idx
+                    expr,
+                    None,
+                    annotation_group_idx,
+                    existing_replacements=replacements,
                 )
                 replacements.update(new_replacements)
                 group.update(expr_group)
         having_replacements, having_group = self._prepare_expressions_for_pipeline(
-            self.having, None, annotation_group_idx
+            self.having,
+            None,
+            annotation_group_idx,
+            existing_replacements=replacements,
         )
         replacements.update(having_replacements)
         group.update(having_group)

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -75,6 +75,9 @@ Bug fixes
   :class:`~django_mongodb_backend.fields.EmbeddedModelField` to a model with a
   :class:`~django_mongodb_backend.fields.EmbeddedModelArrayField`.
 
+- Prevented aggregation queries from generating redundant accumulators in the
+  ``$group`` stage.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/tests/aggregation_/test_mql.py
+++ b/tests/aggregation_/test_mql.py
@@ -1,0 +1,106 @@
+from bson import SON
+from django.db.models import Avg
+from django.test import TestCase
+
+from django_mongodb_backend.test import MongoTestCaseMixin
+
+from .models import Author
+
+
+class AggregationMQLTests(MongoTestCaseMixin, TestCase):
+    def test_group_by_with_having(self):
+        with self.assertNumQueries(1) as ctx:
+            list(Author.objects.values("name").annotate(avg_age=Avg("age")).filter(avg_age__gt=10))
+        self.assertAggregateQuery(
+            ctx.captured_queries[0]["sql"],
+            "aggregation__author",
+            [
+                {
+                    "$group": {
+                        "__aggregation1": {"$avg": "$age"},
+                        "_id": {"name": "$name"},
+                        "avg_age": {"$avg": "$age"},
+                    }
+                },
+                {"$addFields": {"name": "$_id.name"}},
+                {"$unset": "_id"},
+                {"$match": {"__aggregation1": {"$gt": 10.0}}},
+                {"$project": {"avg_age": "$__aggregation1", "name": 1}},
+            ],
+        )
+
+    def test_group_by_with_order_by(self):
+        with self.assertNumQueries(1) as ctx:
+            list(Author.objects.values("name").annotate(avg_age=Avg("age")).order_by("avg_age"))
+        self.assertAggregateQuery(
+            ctx.captured_queries[0]["sql"],
+            "aggregation__author",
+            [
+                {
+                    "$group": {
+                        "__aggregation1": {"$avg": "$age"},
+                        "_id": {"name": "$name"},
+                        "avg_age": {"$avg": "$age"},
+                    }
+                },
+                {"$addFields": {"name": "$_id.name"}},
+                {"$unset": "_id"},
+                {"$project": {"avg_age": "$__aggregation1", "name": 1}},
+                {"$sort": SON([("avg_age", 1)])},
+            ],
+        )
+
+    def test_group_by_with_having_and_order_by(self):
+        with self.assertNumQueries(1) as ctx:
+            list(
+                Author.objects.values("name")
+                .annotate(avg_age=Avg("age"))
+                .filter(avg_age__gt=10)
+                .order_by("avg_age")
+            )
+        self.assertAggregateQuery(
+            ctx.captured_queries[0]["sql"],
+            "aggregation__author",
+            [
+                {
+                    "$group": {
+                        "__aggregation1": {"$avg": "$age"},
+                        "__aggregation2": {"$avg": "$age"},
+                        "_id": {"name": "$name"},
+                        "avg_age": {"$avg": "$age"},
+                    }
+                },
+                {"$addFields": {"name": "$_id.name"}},
+                {"$unset": "_id"},
+                {"$match": {"__aggregation2": {"$gt": 10.0}}},
+                {"$project": {"avg_age": "$__aggregation2", "name": 1}},
+                {"$sort": SON([("avg_age", 1)])},
+            ],
+        )
+
+    def test_same_aggregate_in_multiple_annotations(self):
+        avg = Avg("age")
+        with self.assertNumQueries(1) as ctx:
+            list(Author.objects.values("name").annotate(avg_plus_1=avg + 1, avg_plus_2=avg + 2))
+        self.assertAggregateQuery(
+            ctx.captured_queries[0]["sql"],
+            "aggregation__author",
+            [
+                {
+                    "$group": {
+                        "__aggregation1": {"$avg": "$age"},
+                        "__aggregation2": {"$avg": "$age"},
+                        "_id": {"name": "$name"},
+                    }
+                },
+                {"$addFields": {"name": "$_id.name"}},
+                {"$unset": "_id"},
+                {
+                    "$project": {
+                        "avg_plus_1": {"$add": ["$__aggregation2", {"$literal": 1}]},
+                        "avg_plus_2": {"$add": ["$__aggregation2", {"$literal": 2}]},
+                        "name": 1,
+                    }
+                },
+            ],
+        )

--- a/tests/aggregation_/test_mql.py
+++ b/tests/aggregation_/test_mql.py
@@ -15,17 +15,11 @@ class AggregationMQLTests(MongoTestCaseMixin, TestCase):
             ctx.captured_queries[0]["sql"],
             "aggregation__author",
             [
-                {
-                    "$group": {
-                        "__aggregation1": {"$avg": "$age"},
-                        "_id": {"name": "$name"},
-                        "avg_age": {"$avg": "$age"},
-                    }
-                },
+                {"$group": {"_id": {"name": "$name"}, "avg_age": {"$avg": "$age"}}},
                 {"$addFields": {"name": "$_id.name"}},
                 {"$unset": "_id"},
-                {"$match": {"__aggregation1": {"$gt": 10.0}}},
-                {"$project": {"avg_age": "$__aggregation1", "name": 1}},
+                {"$match": {"avg_age": {"$gt": 10.0}}},
+                {"$project": {"avg_age": 1, "name": 1}},
             ],
         )
 
@@ -36,16 +30,10 @@ class AggregationMQLTests(MongoTestCaseMixin, TestCase):
             ctx.captured_queries[0]["sql"],
             "aggregation__author",
             [
-                {
-                    "$group": {
-                        "__aggregation1": {"$avg": "$age"},
-                        "_id": {"name": "$name"},
-                        "avg_age": {"$avg": "$age"},
-                    }
-                },
+                {"$group": {"_id": {"name": "$name"}, "avg_age": {"$avg": "$age"}}},
                 {"$addFields": {"name": "$_id.name"}},
                 {"$unset": "_id"},
-                {"$project": {"avg_age": "$__aggregation1", "name": 1}},
+                {"$project": {"avg_age": 1, "name": 1}},
                 {"$sort": SON([("avg_age", 1)])},
             ],
         )
@@ -62,18 +50,11 @@ class AggregationMQLTests(MongoTestCaseMixin, TestCase):
             ctx.captured_queries[0]["sql"],
             "aggregation__author",
             [
-                {
-                    "$group": {
-                        "__aggregation1": {"$avg": "$age"},
-                        "__aggregation2": {"$avg": "$age"},
-                        "_id": {"name": "$name"},
-                        "avg_age": {"$avg": "$age"},
-                    }
-                },
+                {"$group": {"_id": {"name": "$name"}, "avg_age": {"$avg": "$age"}}},
                 {"$addFields": {"name": "$_id.name"}},
                 {"$unset": "_id"},
-                {"$match": {"__aggregation2": {"$gt": 10.0}}},
-                {"$project": {"avg_age": "$__aggregation2", "name": 1}},
+                {"$match": {"avg_age": {"$gt": 10.0}}},
+                {"$project": {"avg_age": 1, "name": 1}},
                 {"$sort": SON([("avg_age", 1)])},
             ],
         )
@@ -89,7 +70,6 @@ class AggregationMQLTests(MongoTestCaseMixin, TestCase):
                 {
                     "$group": {
                         "__aggregation1": {"$avg": "$age"},
-                        "__aggregation2": {"$avg": "$age"},
                         "_id": {"name": "$name"},
                     }
                 },
@@ -97,8 +77,8 @@ class AggregationMQLTests(MongoTestCaseMixin, TestCase):
                 {"$unset": "_id"},
                 {
                     "$project": {
-                        "avg_plus_1": {"$add": ["$__aggregation2", {"$literal": 1}]},
-                        "avg_plus_2": {"$add": ["$__aggregation2", {"$literal": 2}]},
+                        "avg_plus_1": {"$add": ["$__aggregation1", {"$literal": 1}]},
+                        "avg_plus_2": {"$add": ["$__aggregation1", {"$literal": 2}]},
                         "name": 1,
                     }
                 },

--- a/tests/lookup_/tests.py
+++ b/tests/lookup_/tests.py
@@ -108,17 +108,11 @@ class LookupMQLTests(MongoTestCaseMixin, TestCase):
             ctx.captured_queries[0]["sql"],
             "lookup__number",
             [
-                {
-                    "$group": {
-                        "__aggregation1": {"$sum": "$num"},
-                        "_id": {"num": "$num"},
-                        "total": {"$sum": "$num"},
-                    }
-                },
+                {"$group": {"_id": {"num": "$num"}, "total": {"$sum": "$num"}}},
                 {"$addFields": {"num": "$_id.num"}},
                 {"$unset": "_id"},
-                {"$match": {"__aggregation1": 1}},
-                {"$project": {"num": 1, "total": "$__aggregation1"}},
+                {"$match": {"total": 1}},
+                {"$project": {"num": 1, "total": 1}},
                 {"$sort": SON([("num", 1)])},
             ],
         )


### PR DESCRIPTION
When the same aggregate expression object is encountered more than once across the annotation, ORDER BY, and HAVING processing passes, _prepare_expressions_for_pipeline() was called separately for each, producing redundant accumulators in the $group stage with the annotation's entry going unused.
    
Pass existing_replacements to every _prepare_expressions_for_pipeline() call so already-processed sub-expressions are skipped rather than re-accumulated.

Each test exercises one of the blocks of code that's modified.

This is intended to be merged as two commits so the fix commit demonstrates the duplicate accumulators that are removed.