### PR TITLE
INTPYTHON-1005 Make makemigrations order embedded model creation before dependent operations

### DIFF
--- a/django_mongodb_backend/db/migrations/autodetector.py
+++ b/django_mongodb_backend/db/migrations/autodetector.py
@@ -1,4 +1,9 @@
-from django.db.migrations.autodetector import MigrationAutodetector as BaseMigrationAutodetector
+from django.db.migrations import operations
+from django.db.migrations.autodetector import (
+    MigrationAutodetector as BaseMigrationAutodetector,
+)
+from django.db.migrations.autodetector import OperationDependency
+from django.db.migrations.utils import resolve_relation
 
 
 class MigrationAutodetector(BaseMigrationAutodetector):
@@ -11,3 +16,38 @@ class MigrationAutodetector(BaseMigrationAutodetector):
         self.new_model_keys |= self.new_unmanaged_keys
         self.new_unmanaged_keys = set()
         super().generate_renamed_models()
+
+    def add_operation(self, app_label, operation, dependencies=None, beginning=False):
+        # Unlike relational fields, embedded model fields don't get a
+        # dependency on the referenced model's creation, since they have no
+        # remote_field. Add a dependency on the CreateModel of any embedded
+        # models so they are created first, whether the embedding field is part
+        # of a CreateModel (e.g. an initial migration) or an AddField /
+        # AlterField (e.g. adding an embedded field to an existing model).
+        # Otherwise the string references that EmbeddedModelField.deconstruct()
+        # serializes can't be resolved while a partial migration state is
+        # rendered (the embedded model wouldn't exist in the state yet).
+        if isinstance(operation, operations.CreateModel):
+            model_name = operation.name_lower
+            fields = (field for _, field in operation.fields)
+        elif isinstance(operation, (operations.AddField, operations.AlterField)):
+            model_name = operation.model_name_lower
+            fields = [operation.field]
+        else:
+            fields = None
+        if fields is not None:
+            dependencies = list(dependencies or [])
+            for field in fields:
+                for embedded_model in self._get_embedded_models(field):
+                    dependency = resolve_relation(embedded_model, app_label, model_name)
+                    dependencies.append(
+                        OperationDependency(*dependency, None, OperationDependency.Type.CREATE)
+                    )
+        super().add_operation(app_label, operation, dependencies=dependencies, beginning=beginning)
+
+    @staticmethod
+    def _get_embedded_models(field):
+        """Yield the model(s) referenced by an embedded model field, if any."""
+        if (embedded_model := getattr(field, "embedded_model", None)) is not None:
+            yield embedded_model
+        yield from getattr(field, "embedded_models", None) or ()

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -81,6 +81,11 @@ Bug fixes
 - Made the :class:`~django.db.models.Sum` aggregation function return ``None``
   instead of ``0`` when no rows match, matching SQL semantics.
 
+- Made ``makemigrations`` correctly order ``CreateModel`` operations for
+  embedded models. If embedded models aren't created before models that
+  reference them, ``migrate`` crashes with ``AttributeError: 'str' object has
+  no attribute '_meta'``.
+
 Backwards incompatible changes
 ------------------------------
 

--- a/tests/migrations_/autodetector/test_embedded_models.py
+++ b/tests/migrations_/autodetector/test_embedded_models.py
@@ -1,0 +1,413 @@
+from django.db.migrations.state import ModelState
+
+from django_mongodb_backend.fields import (
+    EmbeddedModelArrayField,
+    EmbeddedModelField,
+    ObjectIdAutoField,
+    PolymorphicEmbeddedModelArrayField,
+    PolymorphicEmbeddedModelField,
+)
+
+from .base import BaseAutodetectorTests
+
+
+class EmbeddedModelOrderingTests(BaseAutodetectorTests):
+    def test_embedded_models_created_first(self):
+        """
+        A model's CreateModel must be ordered after the CreateModel of any
+        models it embeds. Otherwise the embedded model's string reference can't
+        be resolved while a partial migration state is rendered.
+        """
+        # The models are passed in reverse dependency order (and the default
+        # add order is alphabetical: Billing, Patient, PatientRecord) to ensure
+        # the ordering comes from the embedded model dependency, not chance.
+        changes = self.get_changes(
+            [],
+            [
+                ModelState(
+                    "testapp",
+                    "Patient",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("patient_record", EmbeddedModelField("testapp.PatientRecord")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "PatientRecord",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("billing", EmbeddedModelField("testapp.Billing")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Billing",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["CreateModel", "CreateModel", "CreateModel"]
+        )
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Billing")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="PatientRecord")
+        self.assertOperationAttributes(changes, "testapp", 0, 2, name="Patient")
+
+    def test_polymorphic_embedded_models_created_first(self):
+        changes = self.get_changes(
+            [],
+            [
+                ModelState(
+                    "testapp",
+                    "Owner",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("pet", PolymorphicEmbeddedModelField(("testapp.Cat", "testapp.Dog"))),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Cat",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Dog",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["CreateModel", "CreateModel", "CreateModel"]
+        )
+        # Cat and Dog must both precede Owner.
+        names = [op.name for op in changes["testapp"][0].operations]
+        self.assertEqual(names[2], "Owner")
+        self.assertEqual(set(names[:2]), {"Cat", "Dog"})
+
+    def test_add_embedded_field_after_embedded_model(self):
+        """
+        Adding an embedded field to an existing model and creating the embedded
+        model in the same migration: the embedded model's CreateModel must come
+        before the AddField.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("item", EmbeddedModelField("testapp.Item")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Item",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["CreateModel", "AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Item")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="item")
+
+    def test_add_embedded_field_cross_app_dependency(self):
+        """
+        The embedded model lives in another app, so the AddField migration
+        must depend on the migration that creates it.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "appa",
+                    "Container",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                ),
+            ],
+            [
+                ModelState(
+                    "appa",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("item", EmbeddedModelField("appb.Item")),
+                    ],
+                ),
+                ModelState(
+                    "appb",
+                    "Item",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "appa", 1)
+        self.assertNumberMigrations(changes, "appb", 1)
+        self.assertOperationTypes(changes, "appa", 0, ["AddField"])
+        self.assertMigrationDependencies(changes, "appa", 0, [("appb", "auto_1")])
+
+    def test_alter_embedded_field_after_embedded_model(self):
+        """
+        Repointing an embedded field at a newly created model must order the
+        new model's CreateModel before the AlterField.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Old",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("thing", EmbeddedModelField("testapp.Old")),
+                    ],
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Old",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "New",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("thing", EmbeddedModelField("testapp.New")),
+                    ],
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["CreateModel", "AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="New")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="thing")
+
+    def test_embedded_array_models_created_first(self):
+        # The models are passed in reverse dependency order (and the default
+        # add order is alphabetical: Billing, Patient, PatientRecord) to ensure
+        # the ordering comes from the embedded model dependency, not chance.
+        changes = self.get_changes(
+            [],
+            [
+                ModelState(
+                    "testapp",
+                    "Patient",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("patient_records", EmbeddedModelArrayField("testapp.PatientRecord")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "PatientRecord",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("billings", EmbeddedModelArrayField("testapp.Billing")),
+                    ],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Billing",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["CreateModel", "CreateModel", "CreateModel"]
+        )
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Billing")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="PatientRecord")
+        self.assertOperationAttributes(changes, "testapp", 0, 2, name="Patient")
+
+    def test_polymorphic_embedded_array_models_created_first(self):
+        changes = self.get_changes(
+            [],
+            [
+                ModelState(
+                    "testapp",
+                    "Owner",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        (
+                            "pets",
+                            PolymorphicEmbeddedModelArrayField(("testapp.Cat", "testapp.Dog")),
+                        ),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Cat",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Dog",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(
+            changes, "testapp", 0, ["CreateModel", "CreateModel", "CreateModel"]
+        )
+        # Cat and Dog must both precede Owner.
+        names = [op.name for op in changes["testapp"][0].operations]
+        self.assertEqual(names[2], "Owner")
+        self.assertEqual(set(names[:2]), {"Cat", "Dog"})
+
+    def test_add_embedded_array_field_after_embedded_model(self):
+        """
+        Adding an embedded array field to an existing model and creating the
+        embedded model in the same migration: the embedded model's CreateModel
+        must come before the AddField.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("items", EmbeddedModelArrayField("testapp.Item")),
+                    ],
+                ),
+                ModelState(
+                    "testapp",
+                    "Item",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["CreateModel", "AddField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="Item")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="items")
+
+    def test_add_embedded_array_field_cross_app_dependency(self):
+        """
+        The embedded model lives in another app, so the AddField migration
+        must depend on the migration that creates it.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "appa",
+                    "Container",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                ),
+            ],
+            [
+                ModelState(
+                    "appa",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("items", EmbeddedModelArrayField("appb.Item")),
+                    ],
+                ),
+                ModelState(
+                    "appb",
+                    "Item",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "appa", 1)
+        self.assertNumberMigrations(changes, "appb", 1)
+        self.assertOperationTypes(changes, "appa", 0, ["AddField"])
+        self.assertMigrationDependencies(changes, "appa", 0, [("appb", "auto_1")])
+
+    def test_alter_embedded_array_field_after_embedded_model(self):
+        """
+        Repointing an embedded array field at a newly created model must order
+        the new model's CreateModel before the AlterField.
+        """
+        changes = self.get_changes(
+            [
+                ModelState(
+                    "testapp",
+                    "Old",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("things", EmbeddedModelArrayField("testapp.Old")),
+                    ],
+                ),
+            ],
+            [
+                ModelState(
+                    "testapp",
+                    "Old",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "New",
+                    [("id", ObjectIdAutoField(primary_key=True))],
+                    {"managed": False},
+                ),
+                ModelState(
+                    "testapp",
+                    "Container",
+                    [
+                        ("id", ObjectIdAutoField(primary_key=True)),
+                        ("things", EmbeddedModelArrayField("testapp.New")),
+                    ],
+                ),
+            ],
+        )
+        self.assertNumberMigrations(changes, "testapp", 1)
+        self.assertOperationTypes(changes, "testapp", 0, ["CreateModel", "AlterField"])
+        self.assertOperationAttributes(changes, "testapp", 0, 0, name="New")
+        self.assertOperationAttributes(changes, "testapp", 0, 1, name="things")


### PR DESCRIPTION
INTPYTHON-1005

Embedded model fields reference a model but, unlike relational fields, have no remote_field, so the autodetector didn't make the referencing model's CreateModel (or an AddField/AlterField that adds an embedded field) depend on the embedded model's creation. The embedding operation could be ordered before the embedded model's CreateModel, leaving a dangling reference that can't be resolved while a partial migration state is rendered.

Add a CREATE dependency on each embedded model so it's created first, whether the field is part of a CreateModel, AddField, or AlterField.