### PR TITLE
INTPYTHON-1011 Add support for test database cloning [PoC]

### DIFF
--- a/.github/workflows/runtests.py
+++ b/.github/workflows/runtests.py
@@ -172,7 +172,7 @@ else:
     test_apps.extend(["gis_tests", "gis_tests_"])
 
 runtests = pathlib.Path(__file__).parent.resolve() / "runtests.py"
-run_tests_cmd = f"python3 {runtests} %s --settings %s -v 2"
+run_tests_cmd = f"python3 {runtests} %s --settings %s -v 2 --parallel=3"
 
 shouldFail = False
 for app_name in test_apps:

--- a/django_mongodb_backend/base.py
+++ b/django_mongodb_backend/base.py
@@ -333,8 +333,9 @@ class DatabaseWrapper(BaseDatabaseWrapper):
             return
         # Remove all references to the connection.
         self.connection = None
-        with contextlib.suppress(AttributeError):
-            del self.database
+        for attr in ("database", "auto_encryption_opts", "client_encryption", "key_vault"):
+            with contextlib.suppress(AttributeError):
+                delattr(self, attr)
         del self._connection_pools[self.alias]
         # Then close it.
         connection.close()

--- a/django_mongodb_backend/creation.py
+++ b/django_mongodb_backend/creation.py
@@ -45,6 +45,33 @@ class DatabaseCreation(BaseDatabaseCreation):
         if not keepdb:
             self._destroy_test_db(parameters["dbname"], verbosity=0)
 
+    def _clone_test_db(self, suffix, verbosity, keepdb=False):
+        source_database_name = self.connection.settings_dict["NAME"]
+        target_database_name = self.get_test_db_clone_settings(suffix)["NAME"]
+        self.connection.ensure_connection()
+        client = self.connection.connection
+        if keepdb and target_database_name in client.list_database_names():
+            return
+        client.drop_database(target_database_name)
+        source_db = client[source_database_name]
+        target_db = client[target_database_name]
+        for collection_name in source_db.list_collection_names():
+            if collection_name.startswith("system."):
+                continue
+            source_collection = source_db[collection_name]
+            # Copy documents to the target database.
+            source_collection.aggregate(
+                [{"$out": {"db": target_database_name, "coll": collection_name}}]
+            )
+            # Copy non-_id indexes ($out only creates the _id index).
+            target_collection = target_db[collection_name]
+            for index in source_collection.list_indexes():
+                if index["name"] == "_id_":
+                    continue
+                keys = list(index["key"].items())
+                options = {k: v for k, v in index.items() if k not in {"key", "v", "ns", "name"}}
+                target_collection.create_index(keys, name=index["name"], **options)
+
     def _destroy_test_db(self, test_database_name, verbosity):
         # At this point, settings still points to the non-test database. For
         # MongoDB, it must use the test database.
@@ -64,6 +91,13 @@ class DatabaseCreation(BaseDatabaseCreation):
             self.connection.settings_dict["OPTIONS"][
                 "auto_encryption_opts"
             ]._key_vault_namespace = opts._key_vault_namespace[len(TEST_DATABASE_PREFIX) :]
+
+    def setup_worker_connection(self, _worker_id):
+        super().setup_worker_connection(_worker_id)
+        # super() calls connection.close() which is a no-op for MongoDB.
+        # Instead, the connection pool that points to the non-test database is
+        # closed so that a connection to the test database can be established.
+        self.connection.close_pool()
 
     def mark_expected_failures_and_skips(self):
         super().mark_expected_failures_and_skips()

--- a/django_mongodb_backend/creation.py
+++ b/django_mongodb_backend/creation.py
@@ -97,6 +97,14 @@ class DatabaseCreation(BaseDatabaseCreation):
         # super() calls connection.close() which is a no-op for MongoDB.
         # Instead, the connection pool that points to the non-test database is
         # closed so that a connection to the test database can be established.
+        # For encrypted databases, update the key vault namespace to the clone
+        # database before reconnecting so the new MongoClient uses the correct
+        # key vault.
+        if opts := self.connection.settings_dict["OPTIONS"].get("auto_encryption_opts"):
+            _, key_vault_collection = opts._key_vault_namespace.split(".", 1)
+            opts._key_vault_namespace = (
+                f"{self.connection.settings_dict['NAME']}.{key_vault_collection}"
+            )
         self.connection.close_pool()
 
     def mark_expected_failures_and_skips(self):

--- a/django_mongodb_backend/features.py
+++ b/django_mongodb_backend/features.py
@@ -16,6 +16,7 @@ except ImproperlyConfigured:
 class DatabaseFeatures(GISFeatures, BaseDatabaseFeatures):
     minimum_database_version = (7, 0)
     allow_sliced_subqueries_with_in = False
+    can_clone_databases = True
     allows_multiple_constraints_on_same_fields = False
     can_create_inline_fk = False
     can_introspect_foreign_keys = False

--- a/docs/releases/6.0.x.rst
+++ b/docs/releases/6.0.x.rst
@@ -43,6 +43,8 @@ New features
   :class:`~django_mongodb_backend.indexes.VectorSearchIndex`, which allows
   specifying ``"hnsw"`` (server default) or ``"flat"`` for each vector field.
 
+- Added support for running tests in parallel using :option:`test --parallel`.
+
 Bug fixes
 ---------
 

--- a/tests/backend_/test_base.py
+++ b/tests/backend_/test_base.py
@@ -116,6 +116,7 @@ class DatabaseWrapperConnectionTests(TestCase):
 
     def test_close(self):
         """connection.close() doesn't close the connection."""
+        connection.ensure_connection()
         conn = connection.connection
         self.assertIsNotNone(conn)
         connection.close()
@@ -123,6 +124,7 @@ class DatabaseWrapperConnectionTests(TestCase):
 
     def test_close_pool(self):
         """connection.close_pool() closes the connection."""
+        connection.ensure_connection()
         self.assertIsNotNone(connection.connection)
         connection.close_pool()
         self.assertIsNone(connection.connection)


### PR DESCRIPTION
I'm not sure whether this should be implemented.

For the admin_views case, the 2-process run is fastest wall-time (~3m 09s vs ~4m 20s single-process). The 4-process run shows diminishing returns, which suggests the test suite is bottlenecked on MongoDB I/O rather than CPU, so the overhead of 4 workers (more clone setup, more concurrent MongoDB load) starts to outweigh the parallelism benefit.

```
./runtests.py basic
  ┌──────────┬───────────┬───────────┐
  │ Parallel │ Test time │ Wall time │
  ├──────────┼───────────┼───────────┤
  │ 1        │ 109.0s    │ 2m 04s    │
  ├──────────┼───────────┼───────────┤
  │ 2        │ 66.0s     │ 1m 42s    │
  ├──────────┼───────────┼───────────┤
  │ 4        │ 52.4s     │ 1m 51s    │
  └──────────┴───────────┴───────────┘
```

```
./runtests.py admin_views
 ┌──────────┬───────────┬───────────┐
 │ Parallel │ Test time │ Wall time │
 ├──────────┼───────────┼───────────┤
 │ 1        │ 243.3s    │ 4m 20s    │
 ├──────────┼───────────┼───────────┤
 │ 2        │ 146.3s    │ 3m 09s    │
 ├──────────┼───────────┼───────────┤
 │ 4        │ 109.4s    │ 3m 00s    │
 └──────────┴───────────┴───────────┘
````

In several benchmarks, two workers delivers a ~22% wall-time speedup. Beyond that, the fixed overhead per worker (clone setup, fork, teardown — ~15–18s each) cancels out the gains from further parallelism against a local MongoDB instance.

**Full test suite:**

Before:
- Evergreen 18-19 min / QE: 19-22 min.
- GitHub: 19-20 min / QE: 25-26 min.

There doesn't seem to be a statistical significant difference in the test suite duration depending on the number of processes used.

After (4 processes):
- Evergreen 17-19 min / QE: 24-26 min.
- GitHub: 15-16min / Atlas: 23-24 min.


After (3 processes):
- Evergreen 16-18 min / QE: 24 min.
- GitHub: 16min / Atlas: 22-24 min.


After (2 processes):
- Evergreen 17-19 min / QE: 22-23 min.
- GitHub: 16min / Atlas: 23 min.

Failures remain when trying to clone encrypted collections.