### PR TITLE
Remove unneeded try/except in aggregates

### DIFF
--- a/django_mongodb_backend/aggregates.py
+++ b/django_mongodb_backend/aggregates.py
@@ -1,4 +1,3 @@
-from django.db import NotSupportedError
 from django.db.models.aggregates import (
     Aggregate,
     Count,
@@ -21,19 +20,13 @@ MONGO_AGGREGATIONS = {Count: "sum"}
 
 def aggregate(self, compiler, connection, operator=None, resolve_inner_expression=False):
     agg_expression, *_ = self.get_source_expressions()
-    lhs_mql = None
     if self.filter is not None:
-        try:
-            lhs_mql = self.filter.as_mql(compiler, connection, as_expr=True)
-        except NotSupportedError:
-            # Generate a CASE statement for this AggregateFilter.
-            agg_expression = Case(
-                When(self.filter.condition, then=agg_expression),
-                # Skip rows that don't meet the criteria.
-                default=Remove(),
-            )
-    if lhs_mql is None:
-        lhs_mql = agg_expression.as_mql(compiler, connection, as_expr=True)
+        agg_expression = Case(
+            When(self.filter.condition, then=agg_expression),
+            # Skip rows that don't meet the criteria.
+            default=Remove(),
+        )
+    lhs_mql = agg_expression.as_mql(compiler, connection, as_expr=True)
     if resolve_inner_expression:
         return lhs_mql
     operator = operator or MONGO_AGGREGATIONS.get(self.__class__, self.function.lower())
@@ -48,27 +41,15 @@ def count(self, compiler, connection, resolve_inner_expression=False):
     """
     agg_expression, *_ = self.get_source_expressions()
     if not self.distinct or resolve_inner_expression:
-        lhs_mql = None
         conditions = [IsNull(agg_expression, False)]
         if self.filter:
-            try:
-                lhs_mql = self.filter.as_mql(compiler, connection, as_expr=True)
-            except NotSupportedError:
-                # Generate a CASE statement for this AggregateFilter.
-                conditions.append(self.filter.condition)
-                condition = When(
-                    WhereNode(conditions),
-                    then=agg_expression if self.distinct else Value(1),
-                )
-                inner_expression = Case(condition, default=Remove())
-        else:
-            inner_expression = Case(
-                When(WhereNode(conditions), then=agg_expression if self.distinct else Value(1)),
-                # Skip rows that don't meet the criteria.
-                default=Remove(),
-            )
-        if lhs_mql is None:
-            lhs_mql = inner_expression.as_mql(compiler, connection, as_expr=True)
+            conditions.append(self.filter.condition)
+        inner_expression = Case(
+            When(WhereNode(conditions), then=agg_expression if self.distinct else Value(1)),
+            # Skip rows that don't meet the criteria.
+            default=Remove(),
+        )
+        lhs_mql = inner_expression.as_mql(compiler, connection, as_expr=True)
         if resolve_inner_expression:
             return lhs_mql
         return {"$sum": lhs_mql}

--- a/django_mongodb_backend/compiler.py
+++ b/django_mongodb_backend/compiler.py
@@ -87,7 +87,8 @@ class SQLCompiler(compiler.SQLCompiler):
                 replacing_expr = NullSafeArraySum(inner_column)
             else:
                 replacing_expr = sub_expr.copy()
-                replacing_expr.set_source_expressions([inner_column, None])
+                original_exprs = sub_expr.get_source_expressions()
+                replacing_expr.set_source_expressions([inner_column, *original_exprs[1:]])
         else:
             group[alias] = sub_expr.as_mql(self, self.connection, as_expr=True)
             if isinstance(sub_expr, Sum):


### PR DESCRIPTION
The try/except pattern was copied from Django where the try block is for databases that support the `FILTER` clause in aggregates. This backend always uses `Case` expressions, and it was only a bug in `SQLCompiler` that caused a `Col` to be treated as the `filter` attribute which used the deleted code path.